### PR TITLE
Add HA redis cluster CFN

### DIFF
--- a/templates/addons/redis-cluster.yml
+++ b/templates/addons/redis-cluster.yml
@@ -1,0 +1,123 @@
+Parameters:
+  App:
+    Type: String
+    Description: Your application's name.
+  Env:
+    Type: String
+    Description: The environment name your service, job, or workflow is being deployed to.
+  Name:
+    Type: String
+    Description: The name of the service, job, or workflow being deployed.
+
+Mappings:
+  EnvScalingConfigurationMap:
+    # Create an entry for each environment
+    dev:
+      "EngineVersion": '6.2'
+      "CacheNodeType": 'cache.t2.micro'
+      "NumReplicas": 0
+
+    prod:
+      "EngineVersion": '6.2'
+      "CacheNodeType": 'cache.t2.micro'
+      "NumReplicas": 2
+
+  EngineVersionMap:
+    '6.2':
+      CacheParameterGroupFamily: 'redis6.x'
+    '6.0':
+      CacheParameterGroupFamily: 'redis6.x'
+    '5.0.6':
+      CacheParameterGroupFamily: 'redis5.0'
+    '5.0.4':
+      CacheParameterGroupFamily: 'redis5.0'
+    '5.0.3':
+      CacheParameterGroupFamily: 'redis5.0'
+    '5.0.0':
+      CacheParameterGroupFamily: 'redis5.0'
+    '4.0.10':
+      CacheParameterGroupFamily: 'redis4.0'
+    '3.2.6':
+      CacheParameterGroupFamily: 'redis3.2'
+
+
+Conditions:
+  HasAutomaticFailoverEnabled: !Not [!Equals [!FindInMap [EnvScalingConfigurationMap, !Ref Env, NumReplicas], 0]]
+
+
+Resources:
+
+  CacheParameterGroup:
+    Type: 'AWS::ElastiCache::ParameterGroup'
+    Properties:
+      CacheParameterGroupFamily: !FindInMap
+        - EngineVersionMap
+        - !FindInMap [EnvScalingConfigurationMap, !Ref Env, EngineVersion]
+        - CacheParameterGroupFamily
+      Description: !Ref 'AWS::StackName'
+      Properties: {}
+
+  CacheSubnetGroupName:
+    Type: 'AWS::ElastiCache::SubnetGroup'
+    Properties:
+      Description: !Ref 'AWS::StackName'
+      SubnetIds:
+        - !Select [0, !Split [ ',', { 'Fn::ImportValue': !Sub '${App}-${Env}-PrivateSubnets' } ] ]
+
+  SecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: !Ref 'AWS::StackName'
+      VpcId:
+        'Fn::ImportValue':
+          !Sub '${App}-${Env}-VpcId'
+      SecurityGroupIngress:
+      - IpProtocol: tcp
+        FromPort: 6379
+        ToPort: 6379
+        SourceSecurityGroupId: { 'Fn::ImportValue': !Sub '${App}-${Env}-EnvironmentSecurityGroup' }
+
+  ReplicationGroup:
+    Type: 'AWS::ElastiCache::ReplicationGroup'
+    Properties:
+      ReplicationGroupDescription: !Ref 'AWS::StackName'
+      AtRestEncryptionEnabled: true
+      AutomaticFailoverEnabled: !If [HasAutomaticFailoverEnabled, true, false]
+      MultiAZEnabled: !If [HasAutomaticFailoverEnabled, true, false]
+      CacheNodeType: !FindInMap [EnvScalingConfigurationMap, !Ref Env, CacheNodeType]
+      CacheParameterGroupName: !Ref CacheParameterGroup
+      CacheSubnetGroupName: !Ref CacheSubnetGroupName
+      Engine: redis
+      EngineVersion: !FindInMap [EnvScalingConfigurationMap, !Ref Env, EngineVersion]
+      NumNodeGroups: 1   # run in non clustered mode with 1 master and 0-5 replicas
+      ReplicasPerNodeGroup: !FindInMap [EnvScalingConfigurationMap, !Ref Env, NumReplicas]
+      PreferredMaintenanceWindow: 'sat:07:00-sat:08:00'
+      SecurityGroupIds:
+      - !Ref SecurityGroup
+
+      TransitEncryptionEnabled: true
+    UpdatePolicy:
+      UseOnlineResharding: true
+
+  # Redis endpoint stored in SSM so that other `services` can retrieve the endpoint.
+  EndpointAddressParam:
+    Type: AWS::SSM::Parameter
+    Properties:
+      # Name: !Sub '/copilot/${App}/${Env}/secrets/{{ service.name|upper|replace("-", "_") }}'   # Other services can retrieve the endpoint from this path.
+      Name: !Sub '/copilot/${App}/${Env}/secrets/REDIS_CLUSTER'   # Other services can retrieve the endpoint from this path.
+      Type: String
+      Value: !GetAtt 'ReplicationGroup.PrimaryEndPoint.Address'
+
+Outputs:
+
+  PrimaryEndPointAddress:
+    Description: 'The DNS address of the primary read-write cache node.'
+    Value: !GetAtt 'ReplicationGroup.PrimaryEndPoint.Address'
+    Export:
+      Name: !Sub '${AWS::StackName}-PrimaryEndPointAddress'
+
+  PrimaryEndPointPort:
+    Description: 'The port that the primary read-write cache engine is listening on.'
+    Value: !GetAtt 'ReplicationGroup.PrimaryEndPoint.Port'
+    Export:
+      Name: !Sub '${AWS::StackName}-PrimaryEndPointPort'


### PR DESCRIPTION
No. of replica nodes, engine and instance size configurable per env.
Automatic failover
TLS transport
Cluster can be scaled down to 1 node for non prod environments

Remaining:
incorporate into bootstrap script