### PR TITLE
GPM-472 Add Paketo `buildspec` configuration

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,33 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+        docker: 18
+    commands:
+      - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2&
+      - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"
+  pre_build:
+    commands:
+    - echo Logging in to AWS ECR....
+    - aws --version
+    - $(aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/uktrade)
+    - IMAGE_TAG=$(curl -s 'https://hub.docker.com/v2/repositories/paketobuildpacks/builder/tags?name=-full&page_size=1' | jq -r '.results[].name')
+    - REPOSITORY_URI=public.ecr.aws/uktrade/paketobuildpacks/builder
+  build:
+    commands:
+    - echo Pull started on `date`
+    - echo Pulling the Docker image...
+    - docker pull paketobuildpacks/builder:$IMAGE_TAG
+    - docker tag $REPOSITORY_URI:$IMAGE_TAG $REPOSITORY_URI:$IMAGE_TAG
+  post_build:
+    commands:
+    - echo Pull completed on `date`
+    - echo Pushing to ECR
+    - docker push $REPOSITORY_URI:latest
+    - docker push $REPOSITORY_URI:$IMAGE_TAG
+    - echo Writing metadata...
+    - printf '{"ImageURI":"%s"}' $REPOSITORY_URI:$IMAGE_TAG > metadata.json
+artifacts:
+  files:
+    - metadata.json

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,7 +11,7 @@ phases:
     commands:
     - echo Logging in to AWS ECR....
     - aws --version
-    - $(aws ecr get-login --no-include-email --region us-east-1)
+    - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/uktrade
     - IMAGE_TAG=$(curl -s 'https://hub.docker.com/v2/repositories/paketobuildpacks/builder/tags?name=-full&page_size=1' | jq -r '.results[].name')
     - REPOSITORY_URI=public.ecr.aws/uktrade/paketobuildpacks/builder
   build:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,18 +10,27 @@ phases:
     - echo Logging in to AWS ECR....
     - aws --version
     - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/uktrade
-    - IMAGE_TAG=$(curl -s 'https://hub.docker.com/v2/repositories/paketobuildpacks/builder/tags?name=-full&page_size=1' | jq -r '.results[].name')
-    - REPOSITORY_URI=public.ecr.aws/uktrade/paketobuildpacks/builder
+    - BUILDER_IMAGE_TAG=$(curl -s 'https://hub.docker.com/v2/repositories/paketobuildpacks/builder/tags?name=-full&page_size=1' | jq -r '.results[].name')
+    - BUILDER_REPOSITORY_URI=public.ecr.aws/uktrade/paketobuildpacks/builder
+    - LIFECYCLE_REPOSITORY_URI=public.ecr.aws/uktrade/buildpacksio/lifecycle
   build:
     commands:
     - echo Pull started on `date`
-    - echo Pulling the Docker image...
-    - docker pull paketobuildpacks/builder:$IMAGE_TAG
-    - docker tag paketobuildpacks/builder:$IMAGE_TAG $REPOSITORY_URI:$IMAGE_TAG
-    - docker tag paketobuildpacks/builder:$IMAGE_TAG $REPOSITORY_URI:latest
+    - echo Pulling the Builder Docker image...
+    - docker pull paketobuildpacks/builder:$BUILDER_IMAGE_TAG
+    - docker tag paketobuildpacks/builder:$BUILDER_IMAGE_TAG $BUILDER_REPOSITORY_URI:$BUILDER_IMAGE_TAG
+    - docker tag paketobuildpacks/builder:$BUILDER_IMAGE_TAG $BUILDER_REPOSITORY_URI:latest
+    - echo Pulling the Lifecycle Docker image...
+    - LIFECYCLE_IMAGE_TAG=$(docker inspect paketobuildpacks/builder:$BUILDER_IMAGE_TAG | jq -r '.[].Config.Labels."io.buildpacks.builder.metadata"' | jq -r '.lifecycle.version')
+    - docker pull buildpacksio/lifecycle:$LIFECYCLE_IMAGE_TAG
+    - docker tag buildpacksio/lifecycle:$LIFECYCLE_IMAGE_TAG $LIFECYCLE_REPOSITORY_URI:$LIFECYCLE_IMAGE_TAG
+    - docker tag buildpacksio/lifecycle:$LIFECYCLE_IMAGE_TAG $LIFECYCLE_REPOSITORY_URI:latest
   post_build:
     commands:
     - echo Pull completed on `date`
-    - echo Pushing to ECR
-    - docker push $REPOSITORY_URI:$IMAGE_TAG
-    - docker push $REPOSITORY_URI:latest
+    - echo Pushing Builder image to ECR
+    - docker push $BUILDER_REPOSITORY_URI:$BUILDER_IMAGE_TAG
+    - docker push $BUILDER_REPOSITORY_URI:latest
+    - echo Pushing Lifecycle image to ECR
+    - docker push $LIFECYCLE_REPOSITORY_URI:$BUILDER_IMAGE_TAG
+    - docker push $LIFECYCLE_REPOSITORY_URI:latest

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,7 +19,7 @@ phases:
     - echo Pull started on `date`
     - echo Pulling the Docker image...
     - docker pull paketobuildpacks/builder:$IMAGE_TAG
-    - docker tag $REPOSITORY_URI:$IMAGE_TAG $REPOSITORY_URI:$IMAGE_TAG
+    - docker tag paketobuildpacks/builder:$IMAGE_TAG $REPOSITORY_URI:$IMAGE_TAG
   post_build:
     commands:
     - echo Pull completed on `date`

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -20,12 +20,13 @@ phases:
     - echo Pulling the Docker image...
     - docker pull paketobuildpacks/builder:$IMAGE_TAG
     - docker tag paketobuildpacks/builder:$IMAGE_TAG $REPOSITORY_URI:$IMAGE_TAG
+    - docker tag paketobuildpacks/builder:$IMAGE_TAG $REPOSITORY_URI:latest
   post_build:
     commands:
     - echo Pull completed on `date`
     - echo Pushing to ECR
-    - docker push $REPOSITORY_URI:latest
     - docker push $REPOSITORY_URI:$IMAGE_TAG
+    - docker push $REPOSITORY_URI:latest
     - echo Writing metadata...
     - printf '{"ImageURI":"%s"}' $REPOSITORY_URI:$IMAGE_TAG > metadata.json
 artifacts:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,8 +10,7 @@ phases:
     - echo Logging in to AWS ECR....
     - aws --version
     - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/uktrade
-    - BUILDER_IMAGE_TAG=0.2.326-full
-#    - BUILDER_IMAGE_TAG=$(curl -s 'https://hub.docker.com/v2/repositories/paketobuildpacks/builder/tags?name=-full&page_size=1' | jq -r '.results[].name')
+    - BUILDER_IMAGE_TAG=$(curl -s 'https://hub.docker.com/v2/repositories/paketobuildpacks/builder/tags?name=-full&page_size=1' | jq -r '.results[].name')
     - BUILDER_REPOSITORY_URI=public.ecr.aws/uktrade/paketobuildpacks/builder
     - LIFECYCLE_REPOSITORY_URI=public.ecr.aws/uktrade/buildpacksio/lifecycle
     - RUN_REPOSITORY_URI=public.ecr.aws/uktrade/paketobuildpacks/run

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -37,7 +37,7 @@ phases:
     - docker push $BUILDER_REPOSITORY_URI:$BUILDER_IMAGE_TAG
     - docker push $BUILDER_REPOSITORY_URI:latest
     - echo Pushing Lifecycle image to ECR
-    - docker push $LIFECYCLE_REPOSITORY_URI:$BUILDER_IMAGE_TAG
+    - docker push $LIFECYCLE_REPOSITORY_URI:$LIFECYCLE_IMAGE_TAG
     - docker push $LIFECYCLE_REPOSITORY_URI:latest
     - echo Pushing Run image to ECR
     - docker push $RUN_REPOSITORY_URI:full-cnb

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,7 +10,8 @@ phases:
     - echo Logging in to AWS ECR....
     - aws --version
     - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/uktrade
-    - BUILDER_IMAGE_TAG=$(curl -s 'https://hub.docker.com/v2/repositories/paketobuildpacks/builder/tags?name=-full&page_size=1' | jq -r '.results[].name')
+    - BUILDER_IMAGE_TAG=0.2.326-full
+#    - BUILDER_IMAGE_TAG=$(curl -s 'https://hub.docker.com/v2/repositories/paketobuildpacks/builder/tags?name=-full&page_size=1' | jq -r '.results[].name')
     - BUILDER_REPOSITORY_URI=public.ecr.aws/uktrade/paketobuildpacks/builder
     - LIFECYCLE_REPOSITORY_URI=public.ecr.aws/uktrade/buildpacksio/lifecycle
     - RUN_REPOSITORY_URI=public.ecr.aws/uktrade/paketobuildpacks/run

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,8 +2,6 @@ version: 0.2
 
 phases:
   install:
-    runtime-versions:
-        docker: 20
     commands:
       - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2&
       - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,7 +11,7 @@ phases:
     commands:
     - echo Logging in to AWS ECR....
     - aws --version
-    - $(aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/uktrade)
+    - $(aws ecr get-login --no-include-email --region us-east-1)
     - IMAGE_TAG=$(curl -s 'https://hub.docker.com/v2/repositories/paketobuildpacks/builder/tags?name=-full&page_size=1' | jq -r '.results[].name')
     - REPOSITORY_URI=public.ecr.aws/uktrade/paketobuildpacks/builder
   build:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -3,7 +3,7 @@ version: 0.2
 phases:
   install:
     runtime-versions:
-        docker: 18
+        docker: 20
     commands:
       - nohup /usr/local/bin/dockerd --host=unix:///var/run/docker.sock --host=tcp://127.0.0.1:2375 --storage-driver=overlay2&
       - timeout 15 sh -c "until docker info; do echo .; sleep 1; done"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,6 +13,7 @@ phases:
     - BUILDER_IMAGE_TAG=$(curl -s 'https://hub.docker.com/v2/repositories/paketobuildpacks/builder/tags?name=-full&page_size=1' | jq -r '.results[].name')
     - BUILDER_REPOSITORY_URI=public.ecr.aws/uktrade/paketobuildpacks/builder
     - LIFECYCLE_REPOSITORY_URI=public.ecr.aws/uktrade/buildpacksio/lifecycle
+    - RUN_REPOSITORY_URI=public.ecr.aws/uktrade/paketobuildpacks/run
   build:
     commands:
     - echo Pull started on `date`
@@ -25,6 +26,9 @@ phases:
     - docker pull buildpacksio/lifecycle:$LIFECYCLE_IMAGE_TAG
     - docker tag buildpacksio/lifecycle:$LIFECYCLE_IMAGE_TAG $LIFECYCLE_REPOSITORY_URI:$LIFECYCLE_IMAGE_TAG
     - docker tag buildpacksio/lifecycle:$LIFECYCLE_IMAGE_TAG $LIFECYCLE_REPOSITORY_URI:latest
+    - echo Pulling the Run Docker image...
+    - docker pull paketobuildpacks/run:full-cnb
+    - docker tag paketobuildpacks/run:full-cnb $RUN_REPOSITORY_URI:full-cnb
   post_build:
     commands:
     - echo Pull completed on `date`
@@ -34,3 +38,5 @@ phases:
     - echo Pushing Lifecycle image to ECR
     - docker push $LIFECYCLE_REPOSITORY_URI:$BUILDER_IMAGE_TAG
     - docker push $LIFECYCLE_REPOSITORY_URI:latest
+    - echo Pushing Run image to ECR
+    - docker push $RUN_REPOSITORY_URI:full-cnb

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -25,8 +25,3 @@ phases:
     - echo Pushing to ECR
     - docker push $REPOSITORY_URI:$IMAGE_TAG
     - docker push $REPOSITORY_URI:latest
-    - echo Writing metadata...
-    - printf '{"ImageURI":"%s"}' $REPOSITORY_URI:$IMAGE_TAG > metadata.json
-artifacts:
-  files:
-    - metadata.json


### PR DESCRIPTION
## Context

- Add `buildspec` configuration file for CodeBuild project.
- Automates pulling Docker image from DockerHub to push to public ECR.

### Question(s)

Opinions/thoughts on putting the `buildspec` file in a `paketo` directory rather than in the root directory?