### PR TITLE
Update health check success codes for redirect status codes

### DIFF
--- a/templates/svc/manifest-public.yml
+++ b/templates/svc/manifest-public.yml
@@ -20,7 +20,7 @@ http:
     {% endif -%}
     path: '/'
     port: 8080
-    success_codes: '200'
+    success_codes: '200,301,302'
     healthy_threshold: 3
     unhealthy_threshold: 2
     interval: 35s


### PR DESCRIPTION
## Context

- Allow `301` and `302` success codes as well for health check in the `manifest.yml` file for a service, e.g. `web`.