### PR TITLE
DBTP-169 Use Aurora Postgres min and max capacity from storage config

### DIFF
--- a/templates/addons/env/aurora-postgres.yml
+++ b/templates/addons/env/aurora-postgres.yml
@@ -15,15 +15,14 @@ Parameters:
     Default: main
     # Cannot have special characters
     # Naming constraints: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Limits.html#RDS_Limits.Constraints
+    "service": {{ service }}
 Mappings:
   {{ service.prefix }}EnvScalingConfigurationMap:
-    dev:
-      "DBMinCapacity": 0.5 # AllowedValues: from 0.5 through 128
-      "DBMaxCapacity": 8   # AllowedValues: from 0.5 through 128
-
-    All:
-      "DBMinCapacity": 0.5 # AllowedValues: from 0.5 through 128
-      "DBMaxCapacity": 8   # AllowedValues: from 0.5 through 128
+  {% for environment_name, config in service.environments.items() %}
+    {{ environment_name }}:
+      "DBMinCapacity": {{ config.min_capacity }}
+      "DBMaxCapacity": {{ config.max_capacity }}
+  {% endfor %}
 
 Resources:
   {{ service.prefix }}DBSubnetGroup:


### PR DESCRIPTION
Ticket: https://uktrade.atlassian.net/browse/DBTP-169

It was using hard coded values before.

I have tested this with `update-supply-chain-information` and all is good.