### PR TITLE
Update SSM put_parameter to use Intelligent Tiering

### DIFF
--- a/commands/utils.py
+++ b/commands/utils.py
@@ -49,6 +49,7 @@ def set_ssm_param(app, env, param_name, param_value, overwrite, exists):
             {"Key": "copilot-application", "Value": app},
             {"Key": "copilot-environment", "Value": env},
         ],
+        Tier='Intelligent-Tiering',
     )
 
     if overwrite and exists:


### PR DESCRIPTION
Configuring SSM to use intelligent tiering to allow for secrets with greater than 4096 characters

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ssm/client/put_parameter.html