### PR TITLE
Update MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Department for International Trade
+Copyright (c) 2023 Department for Business and Trade
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Context

When packaging/publishing the Python package, the `LICENSE` file is included, so we need to make sure it is up to date.

## Changes

- Update the year from `2022` -> `2023`
- Update the organisation name from `Department for International Trade` -> `Department for Business and Trade`

## Additional information

JIRA ticket - https://uktrade.atlassian.net/browse/DBTP-135