### PR TITLE
Fix "duplicate SSM parameter name" issue in Opensearch addon template

### DIFF
--- a/templates/addons/env/opensearch.yml
+++ b/templates/addons/env/opensearch.yml
@@ -52,7 +52,6 @@ Resources:
       'aws:copilot:description': 'A Secrets Manager secret to store your OS credentials'
     Type: AWS::SecretsManager::Secret
     Properties:
-      Name: !Sub '/copilot/${App}/${Env}/secrets/{{ service.name|upper|replace("-", "_") }}'
       Description: !Sub Aurora main user secret for ${AWS::StackName}
       GenerateSecretString:
         SecretStringTemplate: '{"username": "opensearch"}'
@@ -203,35 +202,32 @@ Resources:
         - Key: 'Copilot-Environment'
           Value: !Sub ${Env}
 
+  # An intermediate SSM parameter just to store the URL. This is required because attempting use a larger nested Fn::If / Fn::ToJsonString / !Sub / !GetAtt structure
+  # leads to unhelpful "ResourceNotReady: failed waiting for successful resource state: Nested change set " error.
   {{ service.prefix }}OpenSearchEndpointAddressParam:
     Type: AWS::SSM::Parameter
-    Condition: DisableHA
     Properties:
-      Name: !Sub "/copilot/${App}/${Env}/secrets/{{ service.secret_name }}"
       Type: String
-      Value:
-        Fn::ToJsonString:
-          url: !Sub
-            - "https://${url}"
-            - url: !GetAtt {{ service.prefix }}OpenSearchDomain.DomainEndpoint
-          username:
-            !Join [ "",  [ '{% raw %}{{resolve:secretsmanager:{% endraw %}', !Ref {{ service.prefix }}OpenSearchSecret, "{% raw %}:SecretString:username}}{% endraw %}" ]]
-          password:
-            !Join [ "",  [ '{% raw %}{{resolve:secretsmanager:{% endraw %}', !Ref {{ service.prefix }}OpenSearchSecret, "{% raw %}:SecretString:password}}{% endraw %}" ]]
+      Value: !If
+        - EnableHA
+        - !Sub
+          - "https://${url}"
+          - url: !GetAtt dwOpensearchOpenSearchDomainHA.DomainEndpoint
+        - !Sub
+          - "https://${url}"
+          - url: !GetAtt dwOpensearchOpenSearchDomain.DomainEndpoint
 
-  {{ service.prefix }}OpenSearchEndpointAddressParamHA:
+  # The config param containing a json object
+  {{ service.prefix }}OpenSearchEndpointConfigParam:
     Type: AWS::SSM::Parameter
-    Condition: EnableHA
     Properties:
       Name: !Sub "/copilot/${App}/${Env}/secrets/{{ service.secret_name }}"
       Type: String
       Value:
         Fn::ToJsonString:
-          url: !Sub
-            - "https://${url}"
-            - url: !GetAtt {{ service.prefix }}OpenSearchDomainHA.DomainEndpoint
+          url:
+            !Join [ "",  [ '{% raw %}{{resolve:ssm:{% endraw %}', !Ref {{ service.prefix }}OpenSearchEndpointAddressParam, "{% raw %}}}{% endraw %}" ]]
           username:
             !Join [ "",  [ '{% raw %}{{resolve:secretsmanager:{% endraw %}', !Ref {{ service.prefix }}OpenSearchSecret, "{% raw %}:SecretString:username}}{% endraw %}" ]]
           password:
             !Join [ "",  [ '{% raw %}{{resolve:secretsmanager:{% endraw %}', !Ref {{ service.prefix }}OpenSearchSecret, "{% raw %}:SecretString:password}}{% endraw %}" ]]
-

--- a/templates/addons/env/opensearch.yml
+++ b/templates/addons/env/opensearch.yml
@@ -212,10 +212,10 @@ Resources:
         - EnableHA
         - !Sub
           - "https://${url}"
-          - url: !GetAtt dwOpensearchOpenSearchDomainHA.DomainEndpoint
+          - url: !GetAtt {{ service.prefix }}OpenSearchDomainHA.DomainEndpoint
         - !Sub
           - "https://${url}"
-          - url: !GetAtt dwOpensearchOpenSearchDomain.DomainEndpoint
+          - url: !GetAtt {{ service.prefix }}OpenSearchDomain.DomainEndpoint
 
   # The config param containing a json object
   {{ service.prefix }}OpenSearchEndpointConfigParam:


### PR DESCRIPTION
The error was due to having two SSM parameters with the same SSM name, even though CFN conditions meant that only one parameter would be active.

The solution was to use an Fn::if statement to select the endpoint url from the HA or non HA opensearch domain resource based on the EnableHA condition.  However, this resulted in another issue (possibly a CFN bug, or limitation) due to a Fn:If and a complicated nested statement. To solve this I created an intermediate SSM parameter which stores the domain endpoint url, then a final config parameter which retrieves the endpoint url, and the username and password from secrets manager.  We use one secrets manager secret and two SSM parameters, which is not ideal, but required to overcome limitations in cloudformation.