### PR TITLE
Update `copilot-helper` entrypoint

### DIFF
--- a/buildspec.test.yml
+++ b/buildspec.test.yml
@@ -6,6 +6,7 @@ phases:
       - echo Setting local Python versions
       - pyenv versions | awk 'match($0, /\d\.\d+\.\d+/) { print substr($0, RSTART, RLENGTH) }' > .python-version
       - echo Installing dependencies
+      - pip install --upgrade pip
       - pip install poetry
       - poetry install
 

--- a/buildspec.test.yml
+++ b/buildspec.test.yml
@@ -6,7 +6,6 @@ phases:
       - echo Setting local Python versions
       - pyenv versions | awk 'match($0, /\d\.\d+\.\d+/) { print substr($0, RSTART, RLENGTH) }' > .python-version
       - echo Installing dependencies
-      - pip install --upgrade pip
       - pip install poetry
       - poetry install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
 ]
 
 [tool.poetry.scripts]
-copilot-helper = "copilot_helper:cli"
+copilot-helper = "copilot_helper:copilot_helper"
 
 [tool.poetry.dependencies]
 Jinja2 = "3.1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 119
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.5"
+version = "0.1.6"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ packages = [
 copilot-helper = "copilot_helper:copilot_helper"
 
 [tool.poetry.dependencies]
+Cpython = "<3.0.0"
 Jinja2 = "3.1.2"
 PyYAML = "6.0.1"
 boto3 = "^1.26.31"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ packages = [
 copilot-helper = "copilot_helper:copilot_helper"
 
 [tool.poetry.dependencies]
-Cpython = "<3.0.0"
 Jinja2 = "3.1.2"
 PyYAML = "6.0.1"
 boto3 = "^1.26.31"


### PR DESCRIPTION
## Context

- Update `copilot-helper` script entrypoint
  - The entrypoint was still referencing `cli` although it was renamed to `copilot_helper` which caused the script to not work.
- Upgrade version from `0.1.5` -> `0.1.6`