### PR TITLE
Update `make-storage` method

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     rev: 5.12.0
     hooks:
       - id: isort
-        args: [--force-single-line-imports]
+        args: [--force-single-line-imports, --profile, black]
   - repo: https://github.com/myint/docformatter.git
     rev: v1.7.2
     hooks:

--- a/commands/check_cloudformation.py
+++ b/commands/check_cloudformation.py
@@ -32,7 +32,12 @@ def check_cloudformation(ctx: click.Context) -> None:
 
 
 def get_lint_result(path: str):
-    command = ["cfn-lint", path]
+    command = [
+        "cfn-lint",
+        path,
+        "--ignore-templates",
+        f"{BASE_DIR}/tests/test-application/copilot/**/addons/addons.parameters.yml",
+    ]
 
     click.secho(f"\n>>> Running lint check", fg="yellow")
     click.secho(f"""    {" ".join(command)}\n""", fg="yellow")

--- a/commands/check_cloudformation.py
+++ b/commands/check_cloudformation.py
@@ -36,6 +36,7 @@ def get_lint_result(path: str):
         "cfn-lint",
         path,
         "--ignore-templates",
+        # addons.parameters.yml is not a CloudFormation template file
         f"{BASE_DIR}/tests/test-application/copilot/**/addons/addons.parameters.yml",
     ]
 

--- a/commands/copilot_cli.py
+++ b/commands/copilot_cli.py
@@ -161,6 +161,11 @@ def make_storage():
 
         services.append(service)
 
+        if storage_type not in ["s3", "s3-policy"]:
+            contents = templates["env"]["parameters"].render({})
+
+            click.echo(mkfile(output_dir, path / "addons.parameters.yml", contents, overwrite=overwrite))
+
         # s3-policy only applies to individual services
         if storage_type != "s3-policy":
             template = templates["env"][storage_type]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 119
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.8"
+version = "0.1.9"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/test_check_cloudformation.py
+++ b/tests/test_check_cloudformation.py
@@ -6,8 +6,9 @@ from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
 
-from commands.check_cloudformation import \
-    check_cloudformation as check_cloudformation_command
+from commands.check_cloudformation import (
+    check_cloudformation as check_cloudformation_command,
+)
 from tests.conftest import BASE_DIR
 
 
@@ -33,6 +34,7 @@ def test_prepares_cloudformation_templates(copilot_directory: Path) -> None:
         "celery",
         "environments",
         "environments/addons",
+        "environments/addons/addons.parameters.yml",
         "environments/addons/my-aurora-db.yml",
         "environments/addons/my-opensearch.yml",
         "environments/addons/my-rds-db.yml",

--- a/tests/test_copilot_cli.py
+++ b/tests/test_copilot_cli.py
@@ -187,9 +187,13 @@ invalid-entry:
 
         assert result.exit_code == 0
         if storage_type == "s3":
-            assert "File copilot/environments/addons/addons.parameters.yml" not in result.output
+            assert (
+                "File copilot/environments/addons/addons.parameters.yml" not in result.output
+            ), f"addons.parameters.yml should not be included for {storage_type}"
         else:
-            assert "File copilot/environments/addons/addons.parameters.yml overwritten" in result.output
+            assert (
+                "File copilot/environments/addons/addons.parameters.yml overwritten" in result.output
+            ), f"addons.parameters.yml should be included for {storage_type}"
 
     def test_ip_filter_policy_is_applied_to_each_service_by_default(self, fakefs):
         services = ["web", "web-celery"]


### PR DESCRIPTION
## Context

- Add `addons.parameters.yml` to be copied over in the `make-storage` command
  - This file is copied over if the storage type is NOT `s3` or `s3-policy`.
  - This file is also ignored when running `cfn-lint` for the `test-application`.
  - 
- Update version from `0.1.8` -> `0.1.9`
- Update `pre-commit` configuration for `isort` to use the `black` profile
  - `black` and `isort` had conflicting changes in `test_check_cloudformation.py`.