### PR TITLE
DBTP-329 Add error handling

### DIFF
--- a/commands/conduit_cli.py
+++ b/commands/conduit_cli.py
@@ -81,7 +81,12 @@ def tunnel(project_profile: str, app: str, env: str) -> None:
         exit()
 
     if not is_task_running(cluster_arn):
-        secret_arn = get_postgres_secret_arn(app, env)
+        try:
+            secret_arn = get_postgres_secret_arn(app, env)
+        except boto3.client("secretsmanager").exceptions.ResourceNotFoundException:
+            click.secho(f"No secret found matching application {app} and environment {env}.")
+            exit()
+
         create_task(app, env, secret_arn)
 
     exec_into_task(app, env, cluster_arn)

--- a/tests/test_conduit_cli.py
+++ b/tests/test_conduit_cli.py
@@ -175,3 +175,13 @@ def test_tunnel_task_already_running(create_task, exec_into_task, is_task_runnin
 
     assert not create_task.called
     exec_into_task.assert_called_once_with("dbt-app", "staging", cluster_arn)
+
+
+@mock_resourcegroupstaggingapi
+@mock_secretsmanager
+@mock_sts
+@patch("commands.conduit_cli.is_task_running", return_value=False)
+def test_tunnel_secret_not_found(is_task_running, alias_session, mocked_cluster):
+    result = CliRunner().invoke(tunnel, ["--project-profile", "foo", "--app", "dbt-app", "--env", "staging"])
+
+    assert "No secret found matching application dbt-app and environment staging." in result.output


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/DBTP-329

Most of this has already been done in previous tickets, but we don't currently handle the scenario where a secret for an app and env doesn't exist.