### PR TITLE
DBTP-343 Correct Handling of hyphens when getting Load Balancer details

### DIFF
--- a/commands/dns_cli.py
+++ b/commands/dns_cli.py
@@ -328,8 +328,8 @@ def get_load_balancer_domain_and_configuration(
         hyphenated_string, number_of_items_of_interest, number_of_trailing_items
     ):
         # The application name may be hyphenated, so we start splitting
-        # at the hyphen before the trailing items and return the
-        # first items of interest only...
+        # at the hyphen after the first item of interest and return the
+        # items of interest only...
         rsplit = hyphenated_string.rsplit("-", number_of_trailing_items + number_of_items_of_interest - 1)
         interest = rsplit[:number_of_items_of_interest]
         return interest

--- a/commands/dns_cli.py
+++ b/commands/dns_cli.py
@@ -330,9 +330,9 @@ def get_load_balancer_domain_and_configuration(
         # The application name may be hyphenated, so we start splitting
         # at the hyphen after the first item of interest and return the
         # items of interest only...
-        rsplit = hyphenated_string.rsplit("-", number_of_trailing_items + number_of_items_of_interest - 1)
-        interest = rsplit[:number_of_items_of_interest]
-        return interest
+        return hyphenated_string.rsplit("-", number_of_trailing_items + number_of_items_of_interest - 1)[
+            :number_of_items_of_interest
+        ]
 
     proj_client = project_session.client("ecs")
 

--- a/commands/dns_cli.py
+++ b/commands/dns_cli.py
@@ -324,9 +324,15 @@ def check_r53(domain_session, project_session, domain, base_domain):
 def get_load_balancer_domain_and_configuration(
     project_session: Session, app: str, svc: str, env: str
 ) -> Tuple[str, dict]:
-    def separate_hyphenated_application_environment_and_service(hyphenated_string):
-        # The application name may be hyphenated, so we start splitting at the second from last occurrence of a hyphen
-        return hyphenated_string.rsplit("-", 2)
+    def separate_hyphenated_application_environment_and_service(
+        hyphenated_string, number_of_items_of_interest, number_of_trailing_items
+    ):
+        # The application name may be hyphenated, so we start splitting
+        # at the hyphen before the trailing items and return the
+        # first items of interest only...
+        rsplit = hyphenated_string.rsplit("-", number_of_trailing_items + number_of_items_of_interest - 1)
+        interest = rsplit[:number_of_items_of_interest]
+        return interest
 
     proj_client = project_session.client("ecs")
 
@@ -335,9 +341,7 @@ def get_load_balancer_domain_and_configuration(
     no_items = True
     for cluster_arn in response["clusterArns"]:
         cluster_name = cluster_arn.split("/")[1]
-        cluster_name_items = separate_hyphenated_application_environment_and_service(cluster_name)
-        cluster_app = cluster_name_items[0]
-        cluster_env = cluster_name_items[1]
+        cluster_app, cluster_env = separate_hyphenated_application_environment_and_service(cluster_name, 2, 2)
         if cluster_app == app and cluster_env == env:
             no_items = False
             break
@@ -356,7 +360,7 @@ def get_load_balancer_domain_and_configuration(
     for service_arn in response["serviceArns"]:
         fully_qualified_service_name = service_arn.split("/")[2]
         service_app, service_env, service_name = separate_hyphenated_application_environment_and_service(
-            fully_qualified_service_name
+            fully_qualified_service_name, 3, 2
         )
         if service_app == app and service_env == env and service_name == svc:
             no_items = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 119
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.11"
+version = "0.1.12"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/test_dns_cli.py
+++ b/tests/test_dns_cli.py
@@ -183,7 +183,7 @@ def test_get_load_balancer_domain_and_configuration_no_clusters(capfd):
 @mock_ecs
 def test_get_load_balancer_domain_and_configuration_no_services(capfd):
     boto3.Session().client("ecs").create_cluster(
-        clusterName=f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-{ALPHANUMERIC_SERVICE_NAME}"
+        clusterName=f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-Cluster-r4nD0mStR1ng"
     )
     with pytest.raises(SystemExit):
         get_load_balancer_domain_and_configuration(
@@ -199,7 +199,8 @@ def test_get_load_balancer_domain_and_configuration_no_services(capfd):
 @mock_ec2
 @mock_ecs
 def test_get_load_balancer_domain_and_configuration(tmp_path):
-    cluster_name = f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-{ALPHANUMERIC_SERVICE_NAME}"
+    cluster_name = f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-Cluster-r4nD0mStR1ng"
+    service_name = f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-{ALPHANUMERIC_SERVICE_NAME}-Service-r4nD0mStR1ng"
     session = boto3.Session()
     mocked_vpc_id = session.client("ec2").create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
     mocked_subnet_id = session.client("ec2").create_subnet(VpcId=mocked_vpc_id, CidrBlock="10.0.0.0/16")["Subnet"][
@@ -218,7 +219,7 @@ def test_get_load_balancer_domain_and_configuration(tmp_path):
     mocked_ecs_client.create_cluster(clusterName=cluster_name)
     mocked_ecs_client.create_service(
         cluster=cluster_name,
-        serviceName=cluster_name,
+        serviceName=service_name,
         loadBalancers=[{"loadBalancerName": "foo", "targetGroupArn": target_group_arn}],
     )
     mocked_service_manifest_contents = {

--- a/tests/test_dns_cli.py
+++ b/tests/test_dns_cli.py
@@ -183,7 +183,7 @@ def test_get_load_balancer_domain_and_configuration_no_clusters(capfd):
 @mock_ecs
 def test_get_load_balancer_domain_and_configuration_no_services(capfd):
     boto3.Session().client("ecs").create_cluster(
-        clusterName=f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-Cluster-r4nD0mStR1ng"
+        clusterName=f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-Cluster-c0PIlotiD3ntIF3r"
     )
     with pytest.raises(SystemExit):
         get_load_balancer_domain_and_configuration(
@@ -199,8 +199,8 @@ def test_get_load_balancer_domain_and_configuration_no_services(capfd):
 @mock_ec2
 @mock_ecs
 def test_get_load_balancer_domain_and_configuration(tmp_path):
-    cluster_name = f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-Cluster-r4nD0mStR1ng"
-    service_name = f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-{ALPHANUMERIC_SERVICE_NAME}-Service-r4nD0mStR1ng"
+    cluster_name = f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-Cluster-c0PIlotiD3ntIF3r"
+    service_name = f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-{ALPHANUMERIC_SERVICE_NAME}-Service-c0PIlotiD3ntIF3r"
     session = boto3.Session()
     mocked_vpc_id = session.client("ec2").create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
     mocked_subnet_id = session.client("ec2").create_subnet(VpcId=mocked_vpc_id, CidrBlock="10.0.0.0/16")["Subnet"][

--- a/tests/test_dns_cli.py
+++ b/tests/test_dns_cli.py
@@ -22,6 +22,9 @@ from commands.dns_cli import get_load_balancer_domain_and_configuration
 HYPHENATED_APPLICATION_NAME = "hyphenated-application-name"
 ALPHANUMERIC_ENVIRONMENT_NAME = "alphanumericenvironmentname123"
 ALPHANUMERIC_SERVICE_NAME = "alphanumericservicename123"
+COPILOT_IDENTIFIER = "c0PIlotiD3ntIF3r"
+CLUSTER_NAME_SUFFIX = f"Cluster-{COPILOT_IDENTIFIER}"
+SERVICE_NAME_SUFFIX = f"Service-{COPILOT_IDENTIFIER}"
 
 
 # Not much value in testing these while moto doesn't support `describe_certificate`, `list_certificates`
@@ -183,7 +186,7 @@ def test_get_load_balancer_domain_and_configuration_no_clusters(capfd):
 @mock_ecs
 def test_get_load_balancer_domain_and_configuration_no_services(capfd):
     boto3.Session().client("ecs").create_cluster(
-        clusterName=f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-Cluster-c0PIlotiD3ntIF3r"
+        clusterName=f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-{CLUSTER_NAME_SUFFIX}"
     )
     with pytest.raises(SystemExit):
         get_load_balancer_domain_and_configuration(
@@ -199,8 +202,8 @@ def test_get_load_balancer_domain_and_configuration_no_services(capfd):
 @mock_ec2
 @mock_ecs
 def test_get_load_balancer_domain_and_configuration(tmp_path):
-    cluster_name = f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-Cluster-c0PIlotiD3ntIF3r"
-    service_name = f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-{ALPHANUMERIC_SERVICE_NAME}-Service-c0PIlotiD3ntIF3r"
+    cluster_name = f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-{CLUSTER_NAME_SUFFIX}"
+    service_name = f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-{ALPHANUMERIC_SERVICE_NAME}-{SERVICE_NAME_SUFFIX}"
     session = boto3.Session()
     mocked_vpc_id = session.client("ec2").create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
     mocked_subnet_id = session.client("ec2").create_subnet(VpcId=mocked_vpc_id, CidrBlock="10.0.0.0/16")["Subnet"][


### PR DESCRIPTION
For https://uktrade.atlassian.net/browse/DBTP-343

I should have tested my code manually, there were extra hyphen separated things on the end of the cluster and service ARNs in the real world which are not included in the unit tests.