### PR TITLE
DBTP-344 Expedient pass at making `copilot-helper domain check-domain` work

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -8,7 +8,7 @@ phases:
   pre_build:
     commands:
     - echo "3.9" > .python-version
-    - echo Logging in to AWS ECR....
+    - echo Logging in to AWS ECR...
     - aws --version
     - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/uktrade
     - BUILDER_IMAGE_TAG=$(curl -s 'https://hub.docker.com/v2/repositories/paketobuildpacks/builder/tags?name=-full&page_size=1' | jq -r '.results[].name')

--- a/commands/dns_cli.py
+++ b/commands/dns_cli.py
@@ -100,9 +100,10 @@ def create_cert(client, domain_client, domain, base_len):
         response = client.describe_certificate(CertificateArn=arn)
 
     cert_record = response["Certificate"]["DomainValidationOptions"][0]["ResourceRecord"]
-    response = domain_client.list_hosted_zones_by_name()
 
+    click.secho(f"Looking fo ID of domain {domain_to_create}...", fg="yellow")
     domain_id = False
+    response = domain_client.list_hosted_zones_by_name()
     for hz in response["HostedZones"]:
         if hz["Name"] == domain_to_create:
             domain_id = hz["Id"]
@@ -273,7 +274,7 @@ def create_hosted_zone(client, domain, start_domain, base_len):
             ChangeBatch={
                 "Changes": [
                     {
-                        "Action": "UPSERT",
+                        "Action": "CREATE",
                         "ResourceRecordSet": {
                             "Name": subdom,
                             "Type": "NS",

--- a/commands/dns_cli.py
+++ b/commands/dns_cli.py
@@ -23,21 +23,29 @@ MAX_DOMAIN_DEPTH = 2
 AWS_CERT_REGION = "eu-west-2"
 
 
-def wait_for_certificate_validation(acm_client, certificate_arn, sleep_time=5, timeout=600):
-    click.secho("waiting for cert...", fg="yellow")
+def wait_for_certificate_validation(acm_client, certificate_arn, sleep_time=10, timeout=600):
+    click.secho(f"Waiting up to {timeout} seconds for certificate to be validated...", fg="yellow")
     status = acm_client.describe_certificate(CertificateArn=certificate_arn)["Certificate"]["Status"]
     elapsed_time = 0
     while status == "PENDING_VALIDATION":
-        if elapsed_time > timeout:
-            raise Exception(f"Timeout ({timeout}s) reached for certificate validation")
+        if elapsed_time >= timeout:
+            raise Exception(
+                f"Timeout ({timeout}s) reached for certificate validation, might be worth checking things in the AWS Console"
+            )
         click.echo(
             click.style(f"{certificate_arn}", fg="white", bold=True)
-            + click.style(f": Waiting {sleep_time}s for validation, {elapsed_time}s elapsed...", fg="yellow"),
+            + click.style(
+                f": Waiting {sleep_time}s for validation, {timeout - elapsed_time}s until we give up...", fg="yellow"
+            ),
         )
         time.sleep(sleep_time)
         status = acm_client.describe_certificate(CertificateArn=certificate_arn)["Certificate"]["Status"]
         elapsed_time += sleep_time
-    click.secho("cert validated...", fg="green")
+
+    if status == "ISSUED":
+        click.secho("Certificate validated...", fg="green")
+    else:
+        raise Exception(f"""Certificate validation failed with the status "{status}".""")
 
 
 def create_cert(client, domain_client, domain, base_len):
@@ -59,11 +67,11 @@ def create_cert(client, domain_client, domain, base_len):
     # Need to check if cert status is issued, if pending need to update dns
     for cert in resp["CertificateSummaryList"]:
         if domain == cert["DomainName"]:
-            click.secho("Cert already exists, do not need to create.", fg="green")
+            click.secho("Certificate already exists, do not need to create.", fg="green")
             return cert["CertificateArn"]
 
     if not click.confirm(
-        click.style("Creating Cert for ", fg="yellow")
+        click.style("Creating Certificate for ", fg="yellow")
         + click.style(f"{domain}\n", fg="white", bold=True)
         + click.style("Do you want to continue?", fg="yellow"),
     ):
@@ -106,8 +114,10 @@ def create_cert(client, domain_client, domain, base_len):
     click.secho(domain_id, fg="yellow")
 
     if not click.confirm(
-        click.style("Updating DNS record for cert ", fg="yellow")
-        + click.style(f"{domain}\n", fg="white", bold=True)
+        click.style("Updating DNS record for certificate ", fg="yellow")
+        + click.style(f"{domain}", fg="white", bold=True)
+        + click.style(" with value ", fg="yellow")
+        + click.style(f"""{cert_record["Value"]}\n""", fg="white", bold=True)
         + click.style("Do you want to continue?", fg="yellow"),
     ):
         exit()
@@ -131,8 +141,10 @@ def create_cert(client, domain_client, domain, base_len):
         },
     )
 
-    # Wait for certificate to get to validation state before continuing
-    wait_for_certificate_validation(client, certificate_arn=arn, sleep_time=5, timeout=600)
+    # Wait for certificate to get to validation state before continuing.
+    # Will upped the timeout from 600 to 1200 because he repeatedly saw it timeout at 600
+    # and wants to give it a chance to take longer in case that's all that's wrong.
+    wait_for_certificate_validation(client, certificate_arn=arn, timeout=1200)
 
     return arn
 
@@ -229,7 +241,7 @@ def create_hosted_zone(client, domain, start_domain, base_len):
                 break
 
         # update CallerReference to unique string eg date.
-        click.secho(f"Creating hosted zone for {subdom}....", fg="yellow")
+        click.secho(f"Creating hosted zone for {subdom}...", fg="yellow")
         response = client.create_hosted_zone(
             Name=subdom,
             # Timestamp is on the end because CallerReference must be unique for every call
@@ -243,7 +255,7 @@ def create_hosted_zone(client, domain, start_domain, base_len):
 
         if not click.confirm(
             click.style(f"Updating parent {parent} domain with records: ", fg="cyan")
-            + click.style("{ns_records['NameServers']}\n", fg="white", bold=True)
+            + click.style(f"{ns_records['NameServers']}\n", fg="white", bold=True)
             + click.style("Do you want to continue?", fg="cyan"),
         ):
             exit()
@@ -259,7 +271,7 @@ def create_hosted_zone(client, domain, start_domain, base_len):
             ChangeBatch={
                 "Changes": [
                     {
-                        "Action": "CREATE",
+                        "Action": "UPSERT",
                         "ResourceRecordSet": {
                             "Name": subdom,
                             "Type": "NS",
@@ -422,6 +434,12 @@ def domain():
 def check_domain(domain_profile, project_profile, base_domain):
     """Scans to see if Domain exists."""
 
+    # If you need to reset to debug this command, you will need to delete any of the following
+    # which have been created:
+    # the certificate in your application's AWS account,
+    # the hosted zone for the application environment in the dev AWS account,
+    # and the applications records on the hosted zone for the environment in the dev AWS account.
+
     path = "copilot"
 
     domain_session = check_aws_conn(domain_profile)
@@ -447,10 +465,14 @@ def check_domain(domain_profile, project_profile, base_domain):
                             click.style("Checking file: ", fg="cyan")
                             + click.style(os.path.join(root, file), fg="white"),
                         )
-                        click.secho("Domains listed in manifest file", fg="cyan", underline=True)
+                        click.secho("Domains listed in manifest file\n", fg="cyan", underline=True)
 
                         for env, domain in conf["environments"].items():
-                            click.secho("Environment: " + env + "\t=> Domain: " + domain["http"]["alias"], fg="yellow")
+                            click.secho(
+                                "Environment: " + env + " => Domain: " + domain["http"]["alias"],
+                                fg="yellow",
+                                bold=True,
+                            )
                             cert_arn = check_r53(domain_session, project_session, domain["http"]["alias"], base_domain)
                             cert_list.update({domain["http"]["alias"]: cert_arn})
                             click.echo(" ")

--- a/commands/dns_cli.py
+++ b/commands/dns_cli.py
@@ -35,7 +35,8 @@ def wait_for_certificate_validation(acm_client, certificate_arn, sleep_time=10, 
         click.echo(
             click.style(f"{certificate_arn}", fg="white", bold=True)
             + click.style(
-                f": Waiting {sleep_time}s for validation, {timeout - elapsed_time}s until we give up...", fg="yellow"
+                f": Waiting {sleep_time}s for validation, {elapsed_time}s elapsed, {timeout - elapsed_time}s until we give up...",
+                fg="yellow",
             ),
         )
         time.sleep(sleep_time)
@@ -269,7 +270,7 @@ def create_hosted_zone(client, domain, start_domain, base_len):
         nameservers = [f"{nameserver}." for nameserver in nameservers]
         nameserver_resource_records = [{"Value": nameserver} for nameserver in nameservers]
 
-        response = client.change_resource_record_sets(
+        client.change_resource_record_sets(
             HostedZoneId=parent_id,
             ChangeBatch={
                 "Changes": [
@@ -286,7 +287,7 @@ def create_hosted_zone(client, domain, start_domain, base_len):
             },
         )
 
-        return True
+    return True
 
 
 def check_r53(domain_session, project_session, domain, base_domain):

--- a/commands/dns_cli.py
+++ b/commands/dns_cli.py
@@ -98,6 +98,9 @@ def create_cert(client, domain_client, domain, base_len):
         if hz["Name"] == domain_to_create:
             domain_id = hz["Id"]
             break
+    if not domain_id:
+        click.secho(f"Unable to find Domain ID for {domain_to_create} in the hosted zones")
+        exit(1)
 
     # Add NS records of subdomain to parent
     click.secho(domain_id, fg="yellow")
@@ -195,7 +198,7 @@ def check_for_records(client, parent_id, subdom, subdom_id):
         if subdom in records["Name"]:
             click.secho(records["Name"] + " found", fg="green")
             records_to_add.append(records)
-            add_records(client, records, subdom_id)
+            add_records(client, records, subdom_id, "UPSERT")
     return True
 
 
@@ -226,9 +229,11 @@ def create_hosted_zone(client, domain, start_domain, base_len):
                 break
 
         # update CallerReference to unique string eg date.
+        click.secho(f"Creating hosted zone for {subdom}....", fg="yellow")
         response = client.create_hosted_zone(
             Name=subdom,
-            CallerReference=f"{subdom}_from_code",
+            # Timestamp is on the end because CallerReference must be unique for every call
+            CallerReference=f"{subdom}_from_code_{int(time.time())}",
         )
         ns_records = response["DelegationSet"]
         subdom_id = response["HostedZone"]["Id"]
@@ -448,8 +453,10 @@ def check_domain(domain_profile, project_profile, base_domain):
                             click.secho("Environment: " + env + "\t=> Domain: " + domain["http"]["alias"], fg="yellow")
                             cert_arn = check_r53(domain_session, project_session, domain["http"]["alias"], base_domain)
                             cert_list.update({domain["http"]["alias"]: cert_arn})
+                            click.echo(" ")
+
     if cert_list:
-        click.secho("\nHere are your Cert ARNs:", fg="cyan")
+        click.secho("Here are your Certificate ARNs:", fg="cyan")
         for domain, cert in cert_list.items():
             click.secho(f"Domain: {domain}\t => Cert ARN: {cert}", fg="white", bold=True)
     else:

--- a/commands/dns_cli.py
+++ b/commands/dns_cli.py
@@ -102,12 +102,14 @@ def create_cert(client, domain_client, domain, base_len):
     cert_record = response["Certificate"]["DomainValidationOptions"][0]["ResourceRecord"]
     response = domain_client.list_hosted_zones_by_name()
 
+    domain_id = False
     for hz in response["HostedZones"]:
         if hz["Name"] == domain_to_create:
             domain_id = hz["Id"]
             break
     if not domain_id:
-        click.secho(f"Unable to find Domain ID for {domain_to_create} in the hosted zones")
+        # Will got here more than once during manual testing, it might be a race condition we need to handle better
+        click.secho(f"Unable to find Domain ID for {domain_to_create} in the hosted zones", fg="red", bold=True)
         exit(1)
 
     # Add NS records of subdomain to parent

--- a/commands/dns_cli.py
+++ b/commands/dns_cli.py
@@ -244,7 +244,6 @@ def create_hosted_zone(client, domain, start_domain, base_len):
                 parent_id = hz["Id"]
                 break
 
-        # update CallerReference to unique string eg date.
         click.secho(f"Creating hosted zone for {subdom}...", fg="yellow")
         response = client.create_hosted_zone(
             Name=subdom,
@@ -469,20 +468,19 @@ def check_domain(domain_profile, project_profile, base_domain):
                             click.style("Checking file: ", fg="cyan")
                             + click.style(os.path.join(root, file), fg="white"),
                         )
-                        click.secho("Domains listed in manifest file\n", fg="cyan", underline=True)
+                        click.secho("Domains listed in manifest file", fg="cyan", underline=True)
 
                         for env, domain in conf["environments"].items():
                             click.secho(
-                                "Environment: " + env + " => Domain: " + domain["http"]["alias"],
+                                "\nEnvironment: " + env + " => Domain: " + domain["http"]["alias"],
                                 fg="yellow",
                                 bold=True,
                             )
                             cert_arn = check_r53(domain_session, project_session, domain["http"]["alias"], base_domain)
                             cert_list.update({domain["http"]["alias"]: cert_arn})
-                            click.echo(" ")
 
     if cert_list:
-        click.secho("Here are your Certificate ARNs:", fg="cyan")
+        click.secho("\nHere are your Certificate ARNs:", fg="cyan")
         for domain, cert in cert_list.items():
             click.secho(f"Domain: {domain}\t => Cert ARN: {cert}", fg="white", bold=True)
     else:

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -128,7 +128,7 @@ def ensure_cwd_is_repo_root():
 
 def check_aws_conn(aws_profile: str) -> boto3.session.Session:
     # Check that the aws profile exists and is set.
-    click.secho("Checking AWS connection...", fg="cyan")
+    click.secho(f"""Checking AWS connection for profile "{aws_profile}"...""", fg="cyan")
 
     try:
         session = boto3.session.Session(profile_name=aws_profile)
@@ -169,7 +169,7 @@ def check_aws_conn(aws_profile: str) -> boto3.session.Session:
     )
     click.echo(
         click.style(f"User: ", fg="yellow")
-        + click.style(f"{(sts.get_caller_identity()['UserId']).split(':')[-1]}", fg="white", bold=True),
+        + click.style(f"{(sts.get_caller_identity()['UserId']).split(':')[-1]}\n", fg="white", bold=True),
     )
 
     return session

--- a/migration-tools/build-copilot-config.py
+++ b/migration-tools/build-copilot-config.py
@@ -85,8 +85,6 @@ def space_to_copilot_app(app_name, ns_conf):
             continue
 
         web_processes = [p for p in processes if p["type"] == "web"]
-        if len(web_processes) != 1:
-            breakpoint()
         other_proceses = [p for p in processes if p["type"] != "web"]
 
         svc = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 119
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.13"
+version = "0.1.14"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"


### PR DESCRIPTION
For https://uktrade.atlassian.net/browse/DBTP-344, which I think we can maybe defer for today, but need to address pretty soon.

Address some issues we hit when using the `check-domain` command to create a new environment.

Increases the "helpfulness" of the output.

No tests have failed as a result of these changes 😬 

This is in no way the whole of the work required for the ticket, just an expedient attempt to unblock us deploying a new environment while @WillGibson got a lot more familiar with the workings of dns_cli.py than he was before 🤣 