### PR TITLE
Update `copy-secrets` command

### DIFF
--- a/commands/bootstrap_cli.py
+++ b/commands/bootstrap_cli.py
@@ -298,6 +298,8 @@ def copy_secrets(project_profile, source_environment, target_environment):
                     f"""The "{secret_name.split("/")[-1]}" parameter already exists for the "{target_environment}" environment.""",
                     fg="yellow",
                 )
+            else:
+                raise e
 
 
 @bootstrap.command()

--- a/commands/bootstrap_cli.py
+++ b/commands/bootstrap_cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import click
 import yaml
+from botocore.exceptions import ClientError
 from cloudfoundry_client.client import CloudFoundryClient
 from schema import Optional
 from schema import Schema
@@ -278,17 +279,25 @@ def copy_secrets(project_profile, source_environment, target_environment):
 
     for secret in secrets:
         secret_name = secret[0].replace(f"/{source_environment}/", f"/{target_environment}/")
-        set_ssm_param(
-            config["app"],
-            target_environment,
-            secret_name,
-            secret[1],
-            True,
-            True,
-            f"Copied from {source_environment} environment.",
-        )
 
         click.echo(secret_name)
+
+        try:
+            set_ssm_param(
+                config["app"],
+                target_environment,
+                secret_name,
+                secret[1],
+                False,
+                False,
+                f"Copied from {source_environment} environment.",
+            )
+        except ClientError as e:
+            if e.response["Error"]["Code"] == "ParameterAlreadyExists":
+                click.secho(
+                    f"""The "{secret_name.split("/")[-1]}" parameter already exists for the "{target_environment}" environment.""",
+                    fg="yellow",
+                )
 
 
 @bootstrap.command()

--- a/tests/test_bootstrap_cli.py
+++ b/tests/test_bootstrap_cli.py
@@ -320,16 +320,8 @@ def test_copy_secrets(set_ssm_param, get_ssm_secrets, alias_session, aws_credent
         ("/copilot/test-application/development/secrets/TEST_SECRET", "test value"),
     ]
 
-    switch_to_tmp_dir_and_copy_config_file(tmp_path, "test-application/bootstrap.yml")
-    os.mkdir(f"{tmp_path}/copilot")
-
     runner = CliRunner()
-    runner.invoke(make_config)
-
-    my_file = Path(FIXTURES_DIR, "newenv_environment_manifest.yml")
-    os.mkdir(f"{tmp_path}/copilot/environments/newenv")
-    to_file = Path(tmp_path / "copilot/environments/newenv/manifest.yml")
-    shutil.copy(my_file, to_file)
+    setup_newenv_environment(tmp_path, runner)
 
     result = runner.invoke(copy_secrets, ["development", "newenv", "--project-profile", "foo"])
 
@@ -340,8 +332,8 @@ def test_copy_secrets(set_ssm_param, get_ssm_secrets, alias_session, aws_credent
                 "newenv",
                 "/copilot/test-application/newenv/secrets/ALLOWED_HOSTS",
                 "test-application.development.dbt",
-                True,
-                True,
+                False,
+                False,
                 "Copied from development environment.",
             ),
             call(
@@ -349,8 +341,8 @@ def test_copy_secrets(set_ssm_param, get_ssm_secrets, alias_session, aws_credent
                 "newenv",
                 "/copilot/test-application/newenv/secrets/TEST_SECRET",
                 "test value",
-                True,
-                True,
+                False,
+                False,
                 "Copied from development environment.",
             ),
         ]
@@ -363,7 +355,7 @@ def test_copy_secrets(set_ssm_param, get_ssm_secrets, alias_session, aws_credent
 @patch("commands.bootstrap_cli.set_ssm_param")
 @mock_ssm
 @mock_sts
-def test_copy_secrets(set_ssm_param, get_ssm_secrets, alias_session, aws_credentials, tmp_path):
+def test_copy_secrets_with_existing_secret(set_ssm_param, get_ssm_secrets, alias_session, aws_credentials, tmp_path):
     set_ssm_param.side_effect = alias_session.client("ssm").exceptions.ParameterAlreadyExists(
         {
             "Error": {
@@ -378,16 +370,8 @@ def test_copy_secrets(set_ssm_param, get_ssm_secrets, alias_session, aws_credent
         ("/copilot/test-application/development/secrets/TEST_SECRET", "test value"),
     ]
 
-    switch_to_tmp_dir_and_copy_config_file(tmp_path, "test-application/bootstrap.yml")
-    os.mkdir(f"{tmp_path}/copilot")
-
     runner = CliRunner()
-    runner.invoke(make_config)
-
-    my_file = Path(FIXTURES_DIR, "newenv_environment_manifest.yml")
-    os.mkdir(f"{tmp_path}/copilot/environments/newenv")
-    to_file = Path(tmp_path / "copilot/environments/newenv/manifest.yml")
-    shutil.copy(my_file, to_file)
+    setup_newenv_environment(tmp_path, runner)
 
     result = runner.invoke(copy_secrets, ["development", "newenv", "--project-profile", "foo"])
 
@@ -410,3 +394,15 @@ def test_instructions(tmp_path):
 def switch_to_tmp_dir_and_copy_config_file(tmp_path, valid_config_file):
     os.chdir(tmp_path)
     shutil.copy(f"{BASE_DIR}/tests/{valid_config_file}", "bootstrap.yml")
+
+
+def setup_newenv_environment(tmp_path, runner):
+    switch_to_tmp_dir_and_copy_config_file(tmp_path, "test-application/bootstrap.yml")
+    os.mkdir(f"{tmp_path}/copilot")
+
+    runner.invoke(make_config)
+
+    my_file = Path(FIXTURES_DIR, "newenv_environment_manifest.yml")
+    os.mkdir(f"{tmp_path}/copilot/environments/newenv")
+    to_file = Path(tmp_path / "copilot/environments/newenv/manifest.yml")
+    shutil.copy(my_file, to_file)

--- a/tests/test_bootstrap_cli.py
+++ b/tests/test_bootstrap_cli.py
@@ -359,6 +359,41 @@ def test_copy_secrets(set_ssm_param, get_ssm_secrets, alias_session, aws_credent
     assert "/copilot/test-application/newenv/secrets/TEST_SECRET" in result.output
 
 
+@patch("commands.bootstrap_cli.get_ssm_secrets")
+@patch("commands.bootstrap_cli.set_ssm_param")
+@mock_ssm
+@mock_sts
+def test_copy_secrets(set_ssm_param, get_ssm_secrets, alias_session, aws_credentials, tmp_path):
+    set_ssm_param.side_effect = alias_session.client("ssm").exceptions.ParameterAlreadyExists(
+        {
+            "Error": {
+                "Code": "ParameterAlreadyExists",
+                "Message": "The parameter already exists. To overwrite this value, set the overwrite option in the request to true.",
+            },
+        },
+        "PutParameter",
+    )
+
+    get_ssm_secrets.return_value = [
+        ("/copilot/test-application/development/secrets/TEST_SECRET", "test value"),
+    ]
+
+    switch_to_tmp_dir_and_copy_config_file(tmp_path, "test-application/bootstrap.yml")
+    os.mkdir(f"{tmp_path}/copilot")
+
+    runner = CliRunner()
+    runner.invoke(make_config)
+
+    my_file = Path(FIXTURES_DIR, "newenv_environment_manifest.yml")
+    os.mkdir(f"{tmp_path}/copilot/environments/newenv")
+    to_file = Path(tmp_path / "copilot/environments/newenv/manifest.yml")
+    shutil.copy(my_file, to_file)
+
+    result = runner.invoke(copy_secrets, ["development", "newenv", "--project-profile", "foo"])
+
+    assert """The "TEST_SECRET" parameter already exists for the "newenv" environment.""" in result.output
+
+
 def test_instructions(tmp_path):
     """Test that, given the path to a config file, instructions generates output
     for specific services and environments."""


### PR DESCRIPTION
## Context

- Update `copy-secrets` command to properly set tags
  - Display a message if the parameter/secret already exists in Parameter Store for the target environment.
  - Creates the parameter/secret only if it does not exist already.

## Additional information

This has been manually tested as well. We still need to test the utils method - is that part of this ticket or another?

Jira ticket - https://uktrade.atlassian.net/browse/DBTP-350