### PR TITLE
Use defaults for public service healthcheck timeout and interval

### DIFF
--- a/commands/templates/svc/manifest-public.yml
+++ b/commands/templates/svc/manifest-public.yml
@@ -23,8 +23,6 @@ http:
     success_codes: '200,301,302'
     healthy_threshold: 3
     unhealthy_threshold: 2
-    interval: 5s
-    timeout: 30s
     grace_period: 90s
 
 sidecars:

--- a/commands/templates/svc/manifest-public.yml
+++ b/commands/templates/svc/manifest-public.yml
@@ -30,12 +30,7 @@ sidecars:
     port: 443
     image: public.ecr.aws/uktrade/nginx-reverse-proxy:latest
     variables:
-      {% if ipfilter -%}
-      SERVER: localhost:8000
-      {% else -%}
-      SERVER: localhost:8080
-      {% endif %}
-
+      SERVER: localhost:{% if ipfilter %}8000{% else %}8080{% endif %}
 
 {% if ipfilter %}
   ipfilter:
@@ -77,16 +72,15 @@ storage:
 #
 variables:                    # Pass environment variables as key value pairs.
   PORT: 8080
-  {%- for envvar, value in env_vars.items() %}
+{%- for envvar, value in env_vars.items() %}
   {{ envvar }}:
-  {% endfor %}
-
+{%- endfor %}
 
 {% if secrets %}
 secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
   {% for secret, value in secrets.items() -%}
   {{ secret }}: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/{{ value }}
-  {% endfor -%}
+  {%- endfor -%}
 {% else %}
 # secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 {% endif %}

--- a/tests/fixtures/test_service_manifest.yml
+++ b/tests/fixtures/test_service_manifest.yml
@@ -30,8 +30,6 @@ sidecars:
       SERVER: localhost:8000
 
 
-
-
   ipfilter:
     port: 8000
     image: public.ecr.aws/uktrade/ip-filter:latest
@@ -74,11 +72,8 @@ variables:                    # Pass environment variables as key value pairs.
   TEST_VAR:
 
 
-
-
 secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
   TEST_SECRET: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/TEST_SECRET
-
 
 
 # You can override any of the values defined above by environment.

--- a/tests/fixtures/test_service_manifest.yml
+++ b/tests/fixtures/test_service_manifest.yml
@@ -20,8 +20,6 @@ http:
     success_codes: '200,301,302'
     healthy_threshold: 3
     unhealthy_threshold: 2
-    interval: 5s
-    timeout: 30s
     grace_period: 90s
 
 sidecars:
@@ -30,7 +28,7 @@ sidecars:
     image: public.ecr.aws/uktrade/nginx-reverse-proxy:latest
     variables:
       SERVER: localhost:8000
-      
+
 
 
 
@@ -74,13 +72,13 @@ storage:
 variables:                    # Pass environment variables as key value pairs.
   PORT: 8080
   TEST_VAR:
-  
+
 
 
 
 secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
   TEST_SECRET: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/TEST_SECRET
-  
+
 
 
 # You can override any of the values defined above by environment.

--- a/tests/test_bootstrap_cli.py
+++ b/tests/test_bootstrap_cli.py
@@ -116,10 +116,10 @@ def test_make_config(tmp_path):
         assert workspace.read() == "application: test-app"
 
     with open(str(tmp_path / "copilot/environments/test/manifest.yml"), "rb") as test:
-        assert test.read() == test_environment_manifest
+        assert real_line_breaks(test.read()) == real_line_breaks(test_environment_manifest)
 
     with open(str(tmp_path / "copilot/environments/production/manifest.yml"), "rb") as production:
-        assert production.read() == production_environment_manifest
+        assert real_line_breaks(production.read()) == real_line_breaks(production_environment_manifest)
 
     with open(str(tmp_path / "copilot/test-service/manifest.yml"), "rb") as service:
         assert real_line_breaks(service.read()) == real_line_breaks(test_service_manifest)

--- a/tests/test_bootstrap_cli.py
+++ b/tests/test_bootstrap_cli.py
@@ -109,6 +109,9 @@ def test_make_config(tmp_path):
 
     assert (tmp_path / "copilot").exists()
 
+    def real_line_breaks(input: any) -> str:
+        return str(input).replace("\\n", "\n")
+
     with open(str(tmp_path / "copilot/.workspace")) as workspace:
         assert workspace.read() == "application: test-app"
 
@@ -119,7 +122,7 @@ def test_make_config(tmp_path):
         assert production.read() == production_environment_manifest
 
     with open(str(tmp_path / "copilot/test-service/manifest.yml"), "rb") as service:
-        assert service.read() == test_service_manifest
+        assert real_line_breaks(service.read()) == real_line_breaks(test_service_manifest)
 
 
 @mock_sts


### PR DESCRIPTION
As discussed in Slack, we will use the defaults and revisit this as required on a per application basis.