### PR TITLE
Update `make-storage` command

### DIFF
--- a/commands/copilot_cli.py
+++ b/commands/copilot_cli.py
@@ -192,6 +192,12 @@ def make_storage():
                 mkdir(output_dir, service_path)
                 click.echo(mkfile(output_dir, service_path / f"{storage_name}.yml", contents, overwrite=overwrite))
 
+        if storage_type in ["aurora-postgres", "rds-postgres"]:
+            click.secho(
+                "\nNote: The key DATABASE_CREDENTIALS may need to be changed to match your Django settings configuration.",
+                fg="yellow",
+            )
+
     click.echo(templates["storage-instructions"].render(services=services))
 
 

--- a/commands/templates/storage-instructions.txt
+++ b/commands/templates/storage-instructions.txt
@@ -1,12 +1,12 @@
 
 Secret references:
-{% for service in services %}
+{%- for service in services %}
 {%- if service.storage_type == "redis" %}
   REDIS_ENDPOINT: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/{{ service.secret_name }}
 {%- elif service.storage_type == "opensearch" %}
   OPENSEARCH_CREDENTIALS: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/{{ service.secret_name }}
 {%- elif service.storage_type in ["aurora-postgres", "rds-postgres"] %}
   DATABASE_CREDENTIALS:
-    secretsmanager: ${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/{{ service.secret_name }}
+    secretsmanager: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/{{ service.secret_name }}
 {%- endif -%}
 {%- endfor -%}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 119
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.14"
+version = "0.1.15"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/test_copilot_cli.py
+++ b/tests/test_copilot_cli.py
@@ -190,16 +190,6 @@ invalid-entry:
             assert (
                 "File copilot/environments/addons/addons.parameters.yml" not in result.output
             ), f"addons.parameters.yml should not be included for {storage_type}"
-        elif storage_type == "rds-postgres":
-            assert (
-                "secretsmanager: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/RDS"
-                in result.output
-            )
-        elif storage_type == "aurora-postgres":
-            assert (
-                "secretsmanager: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/AURORA"
-                in result.output
-            )
         else:
             assert (
                 "File copilot/environments/addons/addons.parameters.yml overwritten" in result.output
@@ -213,7 +203,7 @@ invalid-entry:
             (AURORA_POSTGRES_STORAGE_CONTENTS, "aurora-postgres"),
         ],
     )
-    def test_env_addons_parameters_file_with_postgres_storage_types(self, fakefs, storage_file_contents, storage_type):
+    def test_storage_instructions_with_postgres_storage_types(self, fakefs, storage_file_contents, storage_type):
         fakefs.create_file(
             "storage.yml",
             contents=storage_file_contents,
@@ -228,10 +218,22 @@ invalid-entry:
             assert (
                 "DATABASE_CREDENTIALS" not in result.output
             ), f"DATABASE_CREDENTIALS should not be included for {storage_type}"
-        else:
+        elif storage_type == "rds-postgres":
             assert (
                 "DATABASE_CREDENTIALS" in result.output
             ), f"DATABASE_CREDENTIALS should be included for {storage_type}"
+            assert (
+                "secretsmanager: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/RDS"
+                in result.output
+            )
+        elif storage_type == "aurora-postgres":
+            assert (
+                "DATABASE_CREDENTIALS" in result.output
+            ), f"DATABASE_CREDENTIALS should be included for {storage_type}"
+            assert (
+                "secretsmanager: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/AURORA"
+                in result.output
+            )
 
     def test_ip_filter_policy_is_applied_to_each_service_by_default(self, fakefs):
         services = ["web", "web-celery"]

--- a/tests/test_copilot_cli.py
+++ b/tests/test_copilot_cli.py
@@ -225,8 +225,8 @@ invalid-entry:
                 "DATABASE_CREDENTIALS" in result.output
             ), f"DATABASE_CREDENTIALS should be included for {storage_type}"
             assert (
-                f"""secretsmanager: /copilot/${{COPILOT_APPLICATION_NAME}}/${{COPILOT_ENVIRONMENT_NAME}}/secrets/{secret_name}"""
-                in result.output
+                "secretsmanager: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/"
+                f"{secret_name}" in result.output
             )
 
     def test_ip_filter_policy_is_applied_to_each_service_by_default(self, fakefs):

--- a/tests/test_copilot_cli.py
+++ b/tests/test_copilot_cli.py
@@ -196,14 +196,16 @@ invalid-entry:
             ), f"addons.parameters.yml should be included for {storage_type}"
 
     @pytest.mark.parametrize(
-        "storage_file_contents, storage_type",
+        "storage_file_contents, storage_type, secret_name",
         [
-            (REDIS_STORAGE_CONTENTS, "redis"),
-            (RDS_POSTGRES_STORAGE_CONTENTS, "rds-postgres"),
-            (AURORA_POSTGRES_STORAGE_CONTENTS, "aurora-postgres"),
+            (REDIS_STORAGE_CONTENTS, "redis", "REDIS"),
+            (RDS_POSTGRES_STORAGE_CONTENTS, "rds-postgres", "RDS"),
+            (AURORA_POSTGRES_STORAGE_CONTENTS, "aurora-postgres", "AURORA"),
         ],
     )
-    def test_storage_instructions_with_postgres_storage_types(self, fakefs, storage_file_contents, storage_type):
+    def test_storage_instructions_with_postgres_storage_types(
+        self, fakefs, storage_file_contents, storage_type, secret_name
+    ):
         fakefs.create_file(
             "storage.yml",
             contents=storage_file_contents,
@@ -218,20 +220,12 @@ invalid-entry:
             assert (
                 "DATABASE_CREDENTIALS" not in result.output
             ), f"DATABASE_CREDENTIALS should not be included for {storage_type}"
-        elif storage_type == "rds-postgres":
+        else:
             assert (
                 "DATABASE_CREDENTIALS" in result.output
             ), f"DATABASE_CREDENTIALS should be included for {storage_type}"
             assert (
-                "secretsmanager: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/RDS"
-                in result.output
-            )
-        elif storage_type == "aurora-postgres":
-            assert (
-                "DATABASE_CREDENTIALS" in result.output
-            ), f"DATABASE_CREDENTIALS should be included for {storage_type}"
-            assert (
-                "secretsmanager: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/AURORA"
+                f"""secretsmanager: /copilot/${{COPILOT_APPLICATION_NAME}}/${{COPILOT_ENVIRONMENT_NAME}}/secrets/{secret_name}"""
                 in result.output
             )
 


### PR DESCRIPTION
## Context

- Update `make-storage` command
  - update the storage instructions template to display additional output for database/Postgres storage types.
  - Update the format of the secrets as well to match the secrets formatting convention.