### PR TITLE
Add new ip filter config with appconfig container

### DIFF
--- a/commands/check_cloudformation.py
+++ b/commands/check_cloudformation.py
@@ -38,6 +38,10 @@ def get_lint_result(path: str):
         "--ignore-templates",
         # addons.parameters.yml is not a CloudFormation template file
         f"{BASE_DIR}/tests/test-application/copilot/**/addons/addons.parameters.yml",
+        # "W2001 Parameter Env not used" is ignored becomes Copilot addons require 
+        # parameters even if they are not used in the Cloudformation template. 
+        "--ignore-checks", 
+        "W2001",
     ]
 
     click.secho(f"\n>>> Running lint check", fg="yellow")

--- a/commands/default-storage.yml
+++ b/commands/default-storage.yml
@@ -1,11 +1,6 @@
 # rules in this file are applied by default
 
-# Add the IP filter policy to every service
-ip-filter:
-  type: s3-policy
-  readonly: true
+# Add the IP filter AppConfig policy to every service
+appconfig-ipfilter:
+  type: appconfig-ipfilter
   services: __all__
-
-  environments:
-    default:
-      bucket-name: ipfilter-config 

--- a/commands/schemas/storage-schema.json
+++ b/commands/schemas/storage-schema.json
@@ -89,7 +89,8 @@
                   "redis",
                   "opensearch",
                   "s3",
-                  "s3-policy"
+                  "s3-policy",
+                  "appconfig-ipfilter"
                ]
             }
          },

--- a/commands/templates/addons/svc/appconfig-ipfilter.yml
+++ b/commands/templates/addons/svc/appconfig-ipfilter.yml
@@ -1,0 +1,27 @@
+Parameters:
+  App:
+    Type: String
+    Description: Your application's name.
+  Env:
+    Type: String
+    Description: The environment name your service, job, or workflow is being deployed to.
+  Name:
+    Type: String
+    Description: The name of the service, job, or workflow being deployed.
+Resources:
+  appConfigAccessPolicy:
+    Metadata:
+      'aws:copilot:description': 'An IAM ManagedPolicy for your service to assume the AppConfig role from the tooling account'
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Allows the service to assume the AppConfig role
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Resource: "arn:aws:iam::763451185160:role/AppConfigIpFilterRole"
+Outputs:
+  appConfigAccessPolicy:
+    Description: "The IAM::ManagedPolicy to attach to the task role"
+    Value: !Ref appConfigAccessPolicy

--- a/commands/templates/svc/manifest-public.yml
+++ b/commands/templates/svc/manifest-public.yml
@@ -34,9 +34,7 @@ sidecars:
     image: public.ecr.aws/uktrade/ip-filter:latest
     variables:
       PORT: 8000
-      EMAIL_NAME: DBT
-      EMAIL: sre-team@digital.trade.gov.uk
-      ORIGIN_HOSTNAME: localhost:8080
+      SERVER: localhost:8080
       APPCONFIG_PROFILES: ipfilter:default:default
       IPFILTER_ENABLED: {{ ipfilter }}
 

--- a/commands/templates/svc/manifest-public.yml
+++ b/commands/templates/svc/manifest-public.yml
@@ -34,7 +34,7 @@ sidecars:
     image: public.ecr.aws/uktrade/ip-filter:latest
     variables:
       PORT: 8000
-      EMAIL_NAME: DIT
+      EMAIL_NAME: DBT
       EMAIL: sre-team@digital.trade.gov.uk
       ORIGIN_HOSTNAME: localhost:8080
       APPCONFIG_PROFILES: ipfilter:default:default

--- a/commands/templates/svc/manifest-public.yml
+++ b/commands/templates/svc/manifest-public.yml
@@ -35,7 +35,7 @@ sidecars:
     variables:
       PORT: 8000
       EMAIL_NAME: DIT
-      EMAIL: sre@digital.trade.gov.uk
+      EMAIL: sre-team@digital.trade.gov.uk
       ORIGIN_HOSTNAME: localhost:8080
       APPCONFIG_PROFILES: ipfilter:default:default
       IPFILTER_ENABLED: {{ ipfilter }}

--- a/commands/templates/svc/manifest-public.yml
+++ b/commands/templates/svc/manifest-public.yml
@@ -15,9 +15,6 @@ http:
   # healthcheck: '/'
   target_container: nginx
   healthcheck:
-    {%- if ipfilter %}
-    {% else %}
-    {% endif -%}
     path: '/'
     port: 8080
     success_codes: '200,301,302'
@@ -30,25 +27,28 @@ sidecars:
     port: 443
     image: public.ecr.aws/uktrade/nginx-reverse-proxy:latest
     variables:
-      SERVER: localhost:{% if ipfilter %}8000{% else %}8080{% endif %}
+      SERVER: localhost:8000
 
-{% if ipfilter %}
   ipfilter:
     port: 8000
     image: public.ecr.aws/uktrade/ip-filter:latest
     variables:
       PORT: 8000
-      EMAIL_NAME: 'The Department for International Trade WebOps team'
-      EMAIL: test@test.test
-      LOG_LEVEL: DEBUG
+      EMAIL_NAME: DIT
+      EMAIL: sre@digital.trade.gov.uk
       ORIGIN_HOSTNAME: localhost:8080
-      ORIGIN_PROTO: http
-      CONFIG_FILE: 's3://ipfilter-config/ROUTES.yaml'
-{% endif %}
+      APPCONFIG_PROFILES: ipfilter:default:default
+      IPFILTER_ENABLED: {{ ipfilter }}
+
+  appconfig:
+    port: 2772
+    image: public.ecr.aws/aws-appconfig/aws-appconfig-agent:2.x
+    essential: true
+    variables:
+      ROLE_ARN: arn:aws:iam::763451185160:role/AppConfigIpFilterRole
 
 # Configuration for your containers and service.
 image:
-
   location: {{ image_location }}
     # Port exposed through your container to route traffic to it.
   port: 8080
@@ -80,7 +80,7 @@ variables:                    # Pass environment variables as key value pairs.
 secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
   {%- for secret, value in secrets.items() %}
   {{ secret }}: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/{{ value }}
-  {%- endfor -%}
+  {% endfor -%}
 {% else %}
 # secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 {% endif %}
@@ -93,5 +93,3 @@ environments:
     http:
       alias: {{ env.url }}
   {%- endfor %}
-
-# TODO: enable/disable ip filter on a per env basis. For example, a service may need the ip filter in non production envs, but not production.

--- a/commands/templates/svc/manifest-public.yml
+++ b/commands/templates/svc/manifest-public.yml
@@ -77,8 +77,7 @@ variables:                    # Pass environment variables as key value pairs.
 {% if secrets %}
 secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
   {%- for secret, value in secrets.items() %}
-  {{ secret }}: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/{{ value }}
-  {% endfor -%}
+  {{ secret }}: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/{{ value }}{% endfor -%}
 {% else %}
 # secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 {% endif %}

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -130,6 +130,8 @@ def setup_templates():
             "public-manifest": templateEnv.get_template("svc/manifest-public.yml"),
             "backend-manifest": templateEnv.get_template("svc/manifest-backend.yml"),
             "s3-policy": templateEnv.get_template("addons/svc/s3-policy.yml"),
+            "s3": templateEnv.get_template("addons/svc/s3-policy.yml"),
+            "appconfig-ipfilter": templateEnv.get_template("addons/svc/appconfig-ipfilter.yml"),
         },
         "env": {
             "manifest": templateEnv.get_template("env/manifest.yml"),

--- a/commands/waf_cli.py
+++ b/commands/waf_cli.py
@@ -100,17 +100,17 @@ def custom_waf(app, project_profile, svc, env, waf_path):
     ensure_cwd_is_repo_root()
     path = Path().resolve() / waf_path
 
+    # The YAML data_dict needs verification, need to create a function to lint/check YAML formatting.
+    result = get_lint_result(str(path))
+    if result.returncode != 0:
+        click.secho(f"File failed lint check.\n{str(path)}", fg="red")
+        exit()
+
     try:
         with open(path, "r") as fd:
             data_dict = load_yaml(fd)
     except FileNotFoundError:
         click.secho(f"File not found...\n{path}", fg="red")
-        exit()
-
-    # The YAML data_dict needs verification, need to create a function to lint/check YAML formatting.
-    result = get_lint_result(str(path))
-    if result.returncode != 0:
-        click.secho(f"File failed lint check.\n{str(path)}", fg="red")
         exit()
 
     # dumper is used to resolve the shorthand in YAML file, eg !GetAtt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 119
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.18"
+version = "0.1.19"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/fixtures/invalid_cloudformation_template.yml
+++ b/tests/fixtures/invalid_cloudformation_template.yml
@@ -9,6 +9,14 @@ Parameters:
     Type: String
     Description: Something to make the linting fail
 
+THIS
+
+TEMPLATE
+
+IS
+
+BROKEN
+
 Resources:
   postgresDBSubnetGroup:
     Type: 'AWS::RDS::DBSubnetGroup'

--- a/tests/fixtures/test_service_manifest.yml
+++ b/tests/fixtures/test_service_manifest.yml
@@ -29,23 +29,26 @@ sidecars:
     variables:
       SERVER: localhost:8000
 
-
   ipfilter:
     port: 8000
     image: public.ecr.aws/uktrade/ip-filter:latest
     variables:
       PORT: 8000
-      EMAIL_NAME: 'The Department for International Trade WebOps team'
-      EMAIL: test@test.test
-      LOG_LEVEL: DEBUG
+      EMAIL_NAME: DIT
+      EMAIL: sre@digital.trade.gov.uk
       ORIGIN_HOSTNAME: localhost:8080
-      ORIGIN_PROTO: http
-      CONFIG_FILE: 's3://ipfilter-config/ROUTES.yaml'
+      APPCONFIG_PROFILES: ipfilter:default:default
+      IPFILTER_ENABLED: True
 
+  appconfig:
+    port: 2772
+    image: public.ecr.aws/aws-appconfig/aws-appconfig-agent:2.x
+    essential: true
+    variables:
+      ROLE_ARN: arn:aws:iam::763451185160:role/AppConfigIpFilterRole
 
 # Configuration for your containers and service.
 image:
-
   location: not-a-url
     # Port exposed through your container to route traffic to it.
   port: 8080
@@ -75,6 +78,7 @@ variables:                    # Pass environment variables as key value pairs.
 secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
   TEST_SECRET: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/TEST_SECRET
   TEST_SECRET_2: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/TEST_SECRET_2
+  
 
 
 # You can override any of the values defined above by environment.
@@ -85,5 +89,3 @@ environments:
   test:
     http:
       alias: test-service.landan.cloudapps.digital
-
-# TODO: enable/disable ip filter on a per env basis. For example, a service may need the ip filter in non production envs, but not production.

--- a/tests/fixtures/test_service_manifest.yml
+++ b/tests/fixtures/test_service_manifest.yml
@@ -75,6 +75,7 @@ variables:                    # Pass environment variables as key value pairs.
 
 secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
   TEST_SECRET: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/TEST_SECRET
+  
   TEST_SECRET_2: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/TEST_SECRET_2
   
 

--- a/tests/fixtures/test_service_manifest.yml
+++ b/tests/fixtures/test_service_manifest.yml
@@ -75,9 +75,7 @@ variables:                    # Pass environment variables as key value pairs.
 
 secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
   TEST_SECRET: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/TEST_SECRET
-  
   TEST_SECRET_2: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/TEST_SECRET_2
-  
 
 
 # You can override any of the values defined above by environment.

--- a/tests/fixtures/test_service_manifest.yml
+++ b/tests/fixtures/test_service_manifest.yml
@@ -34,9 +34,7 @@ sidecars:
     image: public.ecr.aws/uktrade/ip-filter:latest
     variables:
       PORT: 8000
-      EMAIL_NAME: DIT
-      EMAIL: sre@digital.trade.gov.uk
-      ORIGIN_HOSTNAME: localhost:8080
+      SERVER: localhost:8080
       APPCONFIG_PROFILES: ipfilter:default:default
       IPFILTER_ENABLED: True
 

--- a/tests/test_bootstrap_cli.py
+++ b/tests/test_bootstrap_cli.py
@@ -93,9 +93,9 @@ def test_make_config(tmp_path):
     """Test that make_config generates the expected directories and file
     contents."""
 
-    test_environment_manifest = Path(FIXTURES_DIR, "test_environment_manifest.yml").resolve().read_bytes()
-    production_environment_manifest = Path(FIXTURES_DIR, "production_environment_manifest.yml").read_bytes()
-    test_service_manifest = Path(FIXTURES_DIR, "test_service_manifest.yml").read_bytes()
+    test_environment_manifest = Path(FIXTURES_DIR, "test_environment_manifest.yml").read_text()
+    production_environment_manifest = Path(FIXTURES_DIR, "production_environment_manifest.yml").read_text()
+    test_service_manifest = Path(FIXTURES_DIR, "test_service_manifest.yml").read_text()
 
     switch_to_tmp_dir_and_copy_config_file(tmp_path, "test_config.yml")
     os.mkdir(f"{tmp_path}/copilot")
@@ -109,20 +109,17 @@ def test_make_config(tmp_path):
 
     assert (tmp_path / "copilot").exists()
 
-    def real_line_breaks(input: any) -> str:
-        return str(input).replace("\\n", "\n")
-
     with open(str(tmp_path / "copilot/.workspace")) as workspace:
         assert workspace.read() == "application: test-app"
 
-    with open(str(tmp_path / "copilot/environments/test/manifest.yml"), "rb") as test:
-        assert real_line_breaks(test.read()) == real_line_breaks(test_environment_manifest)
+    with open(str(tmp_path / "copilot/environments/test/manifest.yml"), "r") as test:
+        assert test.read() == test_environment_manifest
 
-    with open(str(tmp_path / "copilot/environments/production/manifest.yml"), "rb") as production:
-        assert real_line_breaks(production.read()) == real_line_breaks(production_environment_manifest)
+    with open(str(tmp_path / "copilot/environments/production/manifest.yml"), "r") as production:
+        assert production.read() == production_environment_manifest
 
-    with open(str(tmp_path / "copilot/test-service/manifest.yml"), "rb") as service:
-        assert real_line_breaks(service.read()) == real_line_breaks(test_service_manifest)
+    with open(str(tmp_path / "copilot/test-service/manifest.yml"), "r") as service:
+        assert service.read() == test_service_manifest
 
 
 @mock_sts

--- a/tests/test_bootstrap_cli.py
+++ b/tests/test_bootstrap_cli.py
@@ -112,13 +112,13 @@ def test_make_config(tmp_path):
     with open(str(tmp_path / "copilot/.workspace")) as workspace:
         assert workspace.read() == "application: test-app"
 
-    with open(str(tmp_path / "copilot/environments/test/manifest.yml"), "r") as test:
+    with open(str(tmp_path / "copilot/environments/test/manifest.yml")) as test:
         assert test.read() == test_environment_manifest
 
-    with open(str(tmp_path / "copilot/environments/production/manifest.yml"), "r") as production:
+    with open(str(tmp_path / "copilot/environments/production/manifest.yml")) as production:
         assert production.read() == production_environment_manifest
 
-    with open(str(tmp_path / "copilot/test-service/manifest.yml"), "r") as service:
+    with open(str(tmp_path / "copilot/test-service/manifest.yml")) as service:
         assert service.read() == test_service_manifest
 
 

--- a/tests/test_check_cloudformation.py
+++ b/tests/test_check_cloudformation.py
@@ -91,5 +91,5 @@ def test_outputs_failed_results_summary(patched_prepare_cloudformation_templates
     result = CliRunner().invoke(check_cloudformation_command)
 
     assert (
-        "The CloudFormation templates failed the following checks :-(\n  - lint" in result.output
+       "The CloudFormation templates passed the following checks :-)\n  - lint\n" in result.output
     ), "The failed checks summary was not outputted"

--- a/tests/test_check_cloudformation.py
+++ b/tests/test_check_cloudformation.py
@@ -91,5 +91,5 @@ def test_outputs_failed_results_summary(patched_prepare_cloudformation_templates
     result = CliRunner().invoke(check_cloudformation_command)
 
     assert (
-       "The CloudFormation templates passed the following checks :-)\n  - lint\n" in result.output
+       "The CloudFormation templates failed the following checks :-(\n  - lint\n" in result.output
     ), "The failed checks summary was not outputted"

--- a/tests/test_check_cloudformation.py
+++ b/tests/test_check_cloudformation.py
@@ -45,10 +45,10 @@ def test_prepares_cloudformation_templates(copilot_directory: Path) -> None:
         "environments/staging",
         "s3proxy",
         "s3proxy/addons",
-        "s3proxy/addons/ip-filter.yml",
+        "s3proxy/addons/appconfig-ipfilter.yml",
         "web",
         "web/addons",
-        "web/addons/ip-filter.yml",
+        "web/addons/appconfig-ipfilter.yml",
         "web/addons/my-s3-bucket.yml",
         "web/addons/my-s3-bucket-bucket-access.yml",
     ]

--- a/tests/test_copilot_cli.py
+++ b/tests/test_copilot_cli.py
@@ -229,7 +229,7 @@ invalid-entry:
                 f"{secret_name}" in result.output
             )
 
-    def test_ip_filter_policy_is_applied_to_each_service_by_default(self, fakefs):
+    def test_appconfig_ip_filter_policy_is_applied_to_each_service_by_default(self, fakefs):
         services = ["web", "web-celery"]
 
         fakefs.create_file("./storage.yml")
@@ -246,13 +246,8 @@ invalid-entry:
         result = CliRunner().invoke(cli, ["make-storage"])
 
         for service in services:
-            path = Path(f"copilot/{service}/addons/ip-filter.yml")
+            path = Path(f"copilot/{service}/addons/appconfig-ipfilter.yml")
             assert path.exists()
-
-            with open(path, "r") as fd:
-                s3_policy = yaml.safe_load(fd)
-
-            assert s3_policy["Mappings"]["ipFilterBucketNameMap"] == {"development": {"BucketName": "ipfilter-config"}}
 
         assert result.exit_code == 0
 

--- a/tests/test_storage_validation.py
+++ b/tests/test_storage_validation.py
@@ -33,7 +33,7 @@ mys3bucket:
 
     assert (
         expect_jsonschema_validation_error(storage)
-        == "'not-valid' is not one of ['rds-postgres', 'aurora-postgres', 'redis', 'opensearch', 's3', 's3-policy']"
+        == "'not-valid' is not one of ['rds-postgres', 'aurora-postgres', 'redis', 'opensearch', 's3', 's3-policy', 'appconfig-ipfilter']"
     )
 
 

--- a/tests/test_waf_cli.py
+++ b/tests/test_waf_cli.py
@@ -19,6 +19,8 @@ from commands.waf_cli import check_waf
 from commands.waf_cli import custom_waf
 from tests.conftest import TEST_APP_DIR
 
+import pytest
+
 
 @mock_wafv2
 def test_check_waf():
@@ -125,6 +127,7 @@ def test_custom_waf_file_not_found(alias_session):
     assert result.exit_code == 0
 
 
+@pytest.mark.skip("The WAF logic is broken and needs to be remediated in another PR")
 @mock_cloudformation
 @mock_sts
 def test_custom_waf_invalid_yml(alias_session):

--- a/tests/test_waf_cli.py
+++ b/tests/test_waf_cli.py
@@ -19,8 +19,6 @@ from commands.waf_cli import check_waf
 from commands.waf_cli import custom_waf
 from tests.conftest import TEST_APP_DIR
 
-import pytest
-
 
 @mock_wafv2
 def test_check_waf():
@@ -123,11 +121,10 @@ def test_custom_waf_file_not_found(alias_session):
     )
     path_string = f"{TEST_APP_DIR}/not-a-path"
 
-    assert f"File not found...\n{path_string}" in result.output
+    assert f"File failed lint check.\n{path_string}" in result.output
     assert result.exit_code == 0
 
 
-@pytest.mark.skip("The WAF logic is broken and needs to be remediated in another PR")
 @mock_cloudformation
 @mock_sts
 def test_custom_waf_invalid_yml(alias_session):


### PR DESCRIPTION
This PR adds the appconfig and ipfilter containers.  The new IP filter logic is always inline, but IP filtering can be disabled by setting the an env var: `IPFILTER_ENABLED=False`.  The IP filter can also be disabled on a per environment basis. When disabled the IP filter reverse proxies traffic to the service.

