### PR TITLE
Refactor template logic

### DIFF
--- a/commands/addons-template-map.yml
+++ b/commands/addons-template-map.yml
@@ -2,7 +2,7 @@
 
 # explanation:
 
-# {storage-type}:
+# {addons-type}:
 #   env:
 #     - template: path/to/template.yml
 #       filename: some-fixed-name.yml  - optional, the file name will be the name of the storage item by default

--- a/commands/addons-template-map.yml
+++ b/commands/addons-template-map.yml
@@ -1,0 +1,42 @@
+# This file maps addon types to env and svc level templates
+
+# explanation:
+
+# {storage-type}:
+#   env:
+#     - template: path/to/template.yml
+#       filename: some-fixed-name.yml  - optional, the file name will be the name of the storage item by default
+#   svc:
+#     - template: path/to/template.yml
+
+redis:
+  env:
+    - template: addons/env/redis-cluster.yml
+    - template: addons/env/addons.parameters.yml
+      filename: addons.parameters.yml
+aurora-postgres:
+  env:
+    - template: addons/env/aurora-postgres.yml
+    - template: addons/env/addons.parameters.yml
+      filename: addons.parameters.yml
+rds-postgres:
+  env:
+    - template: addons/env/rds-postgres.yml
+    - template: addons/env/addons.parameters.yml
+      filename: addons.parameters.yml
+opensearch:
+  env:
+    - template: addons/env/rds-postgres.yml
+    - template: addons/env/addons.parameters.yml
+      filename: addons.parameters.yml
+s3:
+  env:
+    - template: addons/env/s3.yml
+  svc:
+    - template: addons/svc/s3-policy.yml
+s3-policy:
+  svc:
+    - template: addons/svc/s3-policy.yml
+appconfig-ipfilter:
+  svc:
+    - template: addons/svc/appconfig-ipfilter.yml

--- a/commands/bootstrap_cli.py
+++ b/commands/bootstrap_cli.py
@@ -155,12 +155,6 @@ def make_config():
 
         click.echo(mkfile(base_path, f"copilot/{name}/manifest.yml", contents))
 
-        # for bs in service.get("backing-services", []):
-        #     bs["prefix"] = camel_case(name + "-" + bs["name"])
-
-        #     contents = templates.get(["svc"][bs["type"]].render(dict(service=bs))
-        #     mkfile(base_path, f"copilot/{name}/addons/{bs['name']}.yml", contents)
-
     # link to GitHub docs
     click.echo(
         "\nGitHub documentation: "

--- a/commands/bootstrap_cli.py
+++ b/commands/bootstrap_cli.py
@@ -134,7 +134,7 @@ def make_config():
     # create each environment directory and manifest.yml
     for name, env in config["environments"].items():
         mkdir(base_path, f"copilot/environments/{name}")
-        contents = templates["env"]["manifest"].render(
+        contents = templates.get_template("env/manifest.yml").render(
             {"name": name, "certificate_arn": env["certificate_arns"][0] if "certificate_arns" in env else ""},
         )
         click.echo(mkfile(base_path, f"copilot/environments/{name}/manifest.yml", contents))
@@ -151,15 +151,15 @@ def make_config():
 
             service["secrets"].update(related_service["secrets"])
 
-        contents = templates["svc"][service["type"] + "-manifest"].render(service)
+        contents = templates.get_template(f"svc/manifest-{service['type']}.yml").render(service)
 
         click.echo(mkfile(base_path, f"copilot/{name}/manifest.yml", contents))
 
-        for bs in service.get("backing-services", []):
-            bs["prefix"] = camel_case(name + "-" + bs["name"])
+        # for bs in service.get("backing-services", []):
+        #     bs["prefix"] = camel_case(name + "-" + bs["name"])
 
-            contents = templates["svc"][bs["type"]].render(dict(service=bs))
-            mkfile(base_path, f"copilot/{name}/addons/{bs['name']}.yml", contents)
+        #     contents = templates.get(["svc"][bs["type"]].render(dict(service=bs))
+        #     mkfile(base_path, f"copilot/{name}/addons/{bs['name']}.yml", contents)
 
     # link to GitHub docs
     click.echo(
@@ -300,7 +300,7 @@ def instructions():
     config = load_and_validate_config(config_file)
     config["config_file"] = config_file
 
-    instructions = templates["instructions"].render(config)
+    instructions = templates.get_template("instructions.txt").render(config)
 
     click.echo(instructions)
 

--- a/commands/check_cloudformation.py
+++ b/commands/check_cloudformation.py
@@ -38,6 +38,10 @@ def get_lint_result(path: str):
         "--ignore-templates",
         # addons.parameters.yml is not a CloudFormation template file
         f"{BASE_DIR}/tests/test-application/copilot/**/addons/addons.parameters.yml",
+        # "W2001 Parameter Env not used" is ignored becomes Copilot addons require 
+        # parameters even if they are not used in the Cloudformation template. 
+        "--ignore-checks", 
+        "W2001",
     ]
 
     click.secho(f"\n>>> Running lint check", fg="yellow")

--- a/commands/copilot_cli.py
+++ b/commands/copilot_cli.py
@@ -160,7 +160,7 @@ def make_storage():
             "storage_type": storage_type,
             **storage_config,
         }
-### ['appconfig-ipfilter', 'my-s3-bucket', 'my-s3-bucket-bucket-access', 'my-redis', 'my-rds-db', 'my-aurora-db', 'my-opensearch']
+
         services.append(environment_addon_config)
 
         service_addon_config = {

--- a/commands/copilot_cli.py
+++ b/commands/copilot_cli.py
@@ -127,10 +127,6 @@ def _validate_and_normalise_config(config_file):
 def make_storage():
     """Generate storage CloudFormation for each environment."""
 
-    # Addons that also require the addons.parameters.yml file to be added due to having
-    # custom cloudformation parameters
-    require_parameters_file = ["redis", "aurora-postgres", "rds-postgres", "opensearch"]
-
     overwrite = True
     output_dir = Path(".").absolute()
 
@@ -139,10 +135,11 @@ def make_storage():
     templates = setup_templates()
 
     config = _validate_and_normalise_config(PACKAGE_DIR / "default-storage.yml")
-
     project_config = _validate_and_normalise_config("storage.yml")
-
     config.update(project_config)
+
+    with open(PACKAGE_DIR / "addons-template-map.yml") as fd:
+        addon_template_map = yaml.safe_load(fd)
 
     click.echo("\n>>> Generating storage cloudformation\n")
 
@@ -151,10 +148,11 @@ def make_storage():
 
     services = []
     for storage_name, storage_config in config.items():
+        print(f">>>>>>>>> {storage_name}")
         storage_type = storage_config.pop("type")
         environments = storage_config.pop("environments")
 
-        service = {
+        environment_addon_config = {
             "secret_name": storage_name.upper().replace("-", "_"),
             "name": storage_config.get("name", None) or storage_name,
             "environments": environments,
@@ -162,39 +160,39 @@ def make_storage():
             "storage_type": storage_type,
             **storage_config,
         }
+### ['appconfig-ipfilter', 'my-s3-bucket', 'my-s3-bucket-bucket-access', 'my-redis', 'my-rds-db', 'my-aurora-db', 'my-opensearch']
+        services.append(environment_addon_config)
 
-        services.append(service)
+        service_addon_config = {
+            "name": storage_config.get("name", None) or storage_name,
+            "prefix": camel_case(storage_name),
+            "environments": environments,
+            **storage_config,
+        }
 
-        if storage_type in require_parameters_file:
-            contents = templates["env"]["parameters"].render({})
+        # generate env addons
+        for addon in addon_template_map[storage_type].get("env", []):
+            template = templates.get_template(addon["template"])
 
-            click.echo(mkfile(output_dir, path / "addons.parameters.yml", contents, overwrite=overwrite))
+            contents = template.render({"service": environment_addon_config})
 
-        # s3-policy only applies to individual services
-        if storage_type in templates["env"]:
-            template = templates["env"][storage_type]
-            contents = template.render({"service": service})
+            filename = addon.get("filename", f"{storage_name}.yml")
 
-            click.echo(mkfile(output_dir, path / f"{storage_name}.yml", contents, overwrite=overwrite))
+            click.echo(mkfile(output_dir, path / filename, contents, overwrite=overwrite))
 
-        # s3 buckets require additional service level cloudformation to grant the ECS task role access to the bucket
-        if storage_type in templates["svc"].keys():
-            template = templates["svc"][storage_type]
+        # generate svc addons
+        for addon in addon_template_map[storage_type].get("svc", []):
+            template = templates.get_template(addon["template"])
 
             for svc in storage_config.get("services", []):
                 service_path = Path(f"copilot/{svc}/addons/")
 
-                service = {
-                    "name": storage_config.get("name", None) or storage_name,
-                    "prefix": camel_case(storage_name),
-                    "environments": environments,
-                    **storage_config,
-                }
+                contents = template.render({"service": service_addon_config})
 
-                contents = template.render({"service": service})
+                filename = addon.get("filename", f"{storage_name}.yml")
 
                 mkdir(output_dir, service_path)
-                click.echo(mkfile(output_dir, service_path / f"{storage_name}.yml", contents, overwrite=overwrite))
+                click.echo(mkfile(output_dir, service_path / filename, contents, overwrite=overwrite))
 
         if storage_type in ["aurora-postgres", "rds-postgres"]:
             click.secho(
@@ -202,7 +200,7 @@ def make_storage():
                 fg="yellow",
             )
 
-    click.echo(templates["storage-instructions"].render(services=services))
+    click.echo(templates.get_template("storage-instructions.txt").render(services=services))
 
 
 @copilot.command()

--- a/commands/default-storage.yml
+++ b/commands/default-storage.yml
@@ -1,11 +1,6 @@
 # rules in this file are applied by default
 
-# Add the IP filter policy to every service
-ip-filter:
-  type: s3-policy
-  readonly: true
+# Add the IP filter AppConfig policy to every service
+appconfig-ipfilter:
+  type: appconfig-ipfilter
   services: __all__
-
-  environments:
-    default:
-      bucket-name: ipfilter-config 

--- a/commands/schemas/storage-schema.json
+++ b/commands/schemas/storage-schema.json
@@ -89,7 +89,8 @@
                   "redis",
                   "opensearch",
                   "s3",
-                  "s3-policy"
+                  "s3-policy",
+                  "appconfig-ipfilter"
                ]
             }
          },

--- a/commands/templates/addons/svc/appconfig-ipfilter.yml
+++ b/commands/templates/addons/svc/appconfig-ipfilter.yml
@@ -1,0 +1,27 @@
+Parameters:
+  App:
+    Type: String
+    Description: Your application's name.
+  Env:
+    Type: String
+    Description: The environment name your service, job, or workflow is being deployed to.
+  Name:
+    Type: String
+    Description: The name of the service, job, or workflow being deployed.
+Resources:
+  appConfigAccessPolicy:
+    Metadata:
+      'aws:copilot:description': 'An IAM ManagedPolicy for your service to assume the AppConfig role from the tooling account'
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Allows the service to assume the AppConfig role
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: sts:AssumeRole
+            Resource: "arn:aws:iam::763451185160:role/AppConfigIpFilterRole"
+Outputs:
+  appConfigAccessPolicy:
+    Description: "The IAM::ManagedPolicy to attach to the task role"
+    Value: !Ref appConfigAccessPolicy

--- a/commands/templates/svc/manifest-public.yml
+++ b/commands/templates/svc/manifest-public.yml
@@ -34,9 +34,7 @@ sidecars:
     image: public.ecr.aws/uktrade/ip-filter:latest
     variables:
       PORT: 8000
-      EMAIL_NAME: DBT
-      EMAIL: sre-team@digital.trade.gov.uk
-      ORIGIN_HOSTNAME: localhost:8080
+      SERVER: localhost:8080
       APPCONFIG_PROFILES: ipfilter:default:default
       IPFILTER_ENABLED: {{ ipfilter }}
 

--- a/commands/templates/svc/manifest-public.yml
+++ b/commands/templates/svc/manifest-public.yml
@@ -34,7 +34,7 @@ sidecars:
     image: public.ecr.aws/uktrade/ip-filter:latest
     variables:
       PORT: 8000
-      EMAIL_NAME: DIT
+      EMAIL_NAME: DBT
       EMAIL: sre-team@digital.trade.gov.uk
       ORIGIN_HOSTNAME: localhost:8080
       APPCONFIG_PROFILES: ipfilter:default:default

--- a/commands/templates/svc/manifest-public.yml
+++ b/commands/templates/svc/manifest-public.yml
@@ -35,7 +35,7 @@ sidecars:
     variables:
       PORT: 8000
       EMAIL_NAME: DIT
-      EMAIL: sre@digital.trade.gov.uk
+      EMAIL: sre-team@digital.trade.gov.uk
       ORIGIN_HOSTNAME: localhost:8080
       APPCONFIG_PROFILES: ipfilter:default:default
       IPFILTER_ENABLED: {{ ipfilter }}

--- a/commands/templates/svc/manifest-public.yml
+++ b/commands/templates/svc/manifest-public.yml
@@ -15,9 +15,6 @@ http:
   # healthcheck: '/'
   target_container: nginx
   healthcheck:
-    {%- if ipfilter %}
-    {% else %}
-    {% endif -%}
     path: '/'
     port: 8080
     success_codes: '200,301,302'
@@ -30,25 +27,28 @@ sidecars:
     port: 443
     image: public.ecr.aws/uktrade/nginx-reverse-proxy:latest
     variables:
-      SERVER: localhost:{% if ipfilter %}8000{% else %}8080{% endif %}
+      SERVER: localhost:8000
 
-{% if ipfilter %}
   ipfilter:
     port: 8000
     image: public.ecr.aws/uktrade/ip-filter:latest
     variables:
       PORT: 8000
-      EMAIL_NAME: 'The Department for International Trade WebOps team'
-      EMAIL: test@test.test
-      LOG_LEVEL: DEBUG
+      EMAIL_NAME: DIT
+      EMAIL: sre@digital.trade.gov.uk
       ORIGIN_HOSTNAME: localhost:8080
-      ORIGIN_PROTO: http
-      CONFIG_FILE: 's3://ipfilter-config/ROUTES.yaml'
-{% endif %}
+      APPCONFIG_PROFILES: ipfilter:default:default
+      IPFILTER_ENABLED: {{ ipfilter }}
+
+  appconfig:
+    port: 2772
+    image: public.ecr.aws/aws-appconfig/aws-appconfig-agent:2.x
+    essential: true
+    variables:
+      ROLE_ARN: arn:aws:iam::763451185160:role/AppConfigIpFilterRole
 
 # Configuration for your containers and service.
 image:
-
   location: {{ image_location }}
     # Port exposed through your container to route traffic to it.
   port: 8080
@@ -80,7 +80,7 @@ variables:                    # Pass environment variables as key value pairs.
 secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
   {% for secret, value in secrets.items() -%}
   {{ secret }}: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/{{ value }}
-  {%- endfor -%}
+  {% endfor -%}
 {% else %}
 # secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
 {% endif %}
@@ -93,5 +93,3 @@ environments:
     http:
       alias: {{ env.url }}
   {%- endfor %}
-
-# TODO: enable/disable ip filter on a per env basis. For example, a service may need the ip filter in non production envs, but not production.

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -123,29 +123,7 @@ def setup_templates():
     templateLoader = jinja2.PackageLoader("commands")
     templateEnv = jinja2.Environment(loader=templateLoader, keep_trailing_newline=True)
 
-    templates = {
-        "instructions": templateEnv.get_template("instructions.txt"),
-        "storage-instructions": templateEnv.get_template("storage-instructions.txt"),
-        "svc": {
-            "public-manifest": templateEnv.get_template("svc/manifest-public.yml"),
-            "backend-manifest": templateEnv.get_template("svc/manifest-backend.yml"),
-            "s3-policy": templateEnv.get_template("addons/svc/s3-policy.yml"),
-            "s3": templateEnv.get_template("addons/svc/s3-policy.yml"),
-            "appconfig-ipfilter": templateEnv.get_template("addons/svc/appconfig-ipfilter.yml"),
-        },
-        "env": {
-            "manifest": templateEnv.get_template("env/manifest.yml"),
-            "opensearch": templateEnv.get_template("addons/env/opensearch.yml"),
-            "rds-postgres": templateEnv.get_template("addons/env/rds-postgres.yml"),
-            "aurora-postgres": templateEnv.get_template("addons/env/aurora-postgres.yml"),
-            "redis": templateEnv.get_template("addons/env/redis-cluster.yml"),
-            "s3": templateEnv.get_template("addons/env/s3.yml"),
-            "parameters": templateEnv.get_template("addons/env/addons.parameters.yml"),
-        },
-        "docs": templateEnv.get_template("COMMANDS.md.jinja"),
-    }
-
-    return templates
+    return templateEnv
 
 
 def ensure_cwd_is_repo_root():

--- a/commands/utils.py
+++ b/commands/utils.py
@@ -130,6 +130,8 @@ def setup_templates():
             "public-manifest": templateEnv.get_template("svc/manifest-public.yml"),
             "backend-manifest": templateEnv.get_template("svc/manifest-backend.yml"),
             "s3-policy": templateEnv.get_template("addons/svc/s3-policy.yml"),
+            "s3": templateEnv.get_template("addons/svc/s3-policy.yml"),
+            "appconfig-ipfilter": templateEnv.get_template("addons/svc/appconfig-ipfilter.yml"),
         },
         "env": {
             "manifest": templateEnv.get_template("env/manifest.yml"),

--- a/commands/waf_cli.py
+++ b/commands/waf_cli.py
@@ -95,7 +95,7 @@ def create_stack(cf_client, app, svc, env, raw):
 @click.option("--waf-path", help="path to waf.yml file", required=True)
 def custom_waf(app, project_profile, svc, env, waf_path):
     """Attach custom WAF to ECS Load Balancer."""
-    # breakpoint()
+
     project_session = check_aws_conn(project_profile)
     ensure_cwd_is_repo_root()
     path = Path().resolve() / waf_path

--- a/commands/waf_cli.py
+++ b/commands/waf_cli.py
@@ -95,7 +95,7 @@ def create_stack(cf_client, app, svc, env, raw):
 @click.option("--waf-path", help="path to waf.yml file", required=True)
 def custom_waf(app, project_profile, svc, env, waf_path):
     """Attach custom WAF to ECS Load Balancer."""
-
+    # breakpoint()
     project_session = check_aws_conn(project_profile)
     ensure_cwd_is_repo_root()
     path = Path().resolve() / waf_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 119
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.15"
+version = "0.1.16"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ def fakefs(fs):
     fs.add_real_directory(BASE_DIR / "commands/schemas")
     fs.add_real_file(BASE_DIR / "commands/storage-plans.yml")
     fs.add_real_file(BASE_DIR / "commands/default-storage.yml")
+    fs.add_real_file(BASE_DIR / "commands/addons-template-map.yml")
     fs.add_real_directory(Path(jsonschema.__path__[0]) / "schemas/vocabularies")
 
     return fs

--- a/tests/fixtures/invalid_cloudformation_template.yml
+++ b/tests/fixtures/invalid_cloudformation_template.yml
@@ -16,3 +16,4 @@ Resources:
       DBSubnetGroupDescription: Group of Copilot private subnets for Aurora Serverless v2 cluster.
       SubnetIds:
         !Split [',', { 'Fn::ImportValue': !Sub '${App}-${Env}-PrivateSubnets' }]
+

--- a/tests/fixtures/test_service_manifest.yml
+++ b/tests/fixtures/test_service_manifest.yml
@@ -34,9 +34,7 @@ sidecars:
     image: public.ecr.aws/uktrade/ip-filter:latest
     variables:
       PORT: 8000
-      EMAIL_NAME: DIT
-      EMAIL: sre@digital.trade.gov.uk
-      ORIGIN_HOSTNAME: localhost:8080
+      SERVER: localhost:8080
       APPCONFIG_PROFILES: ipfilter:default:default
       IPFILTER_ENABLED: True
 

--- a/tests/fixtures/test_service_manifest.yml
+++ b/tests/fixtures/test_service_manifest.yml
@@ -29,23 +29,26 @@ sidecars:
     variables:
       SERVER: localhost:8000
 
-
   ipfilter:
     port: 8000
     image: public.ecr.aws/uktrade/ip-filter:latest
     variables:
       PORT: 8000
-      EMAIL_NAME: 'The Department for International Trade WebOps team'
-      EMAIL: test@test.test
-      LOG_LEVEL: DEBUG
+      EMAIL_NAME: DIT
+      EMAIL: sre@digital.trade.gov.uk
       ORIGIN_HOSTNAME: localhost:8080
-      ORIGIN_PROTO: http
-      CONFIG_FILE: 's3://ipfilter-config/ROUTES.yaml'
+      APPCONFIG_PROFILES: ipfilter:default:default
+      IPFILTER_ENABLED: True
 
+  appconfig:
+    port: 2772
+    image: public.ecr.aws/aws-appconfig/aws-appconfig-agent:2.x
+    essential: true
+    variables:
+      ROLE_ARN: arn:aws:iam::763451185160:role/AppConfigIpFilterRole
 
 # Configuration for your containers and service.
 image:
-
   location: not-a-url
     # Port exposed through your container to route traffic to it.
   port: 8080
@@ -74,6 +77,7 @@ variables:                    # Pass environment variables as key value pairs.
 
 secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
   TEST_SECRET: /copilot/${COPILOT_APPLICATION_NAME}/${COPILOT_ENVIRONMENT_NAME}/secrets/TEST_SECRET
+  
 
 
 # You can override any of the values defined above by environment.
@@ -84,5 +88,3 @@ environments:
   test:
     http:
       alias: test-service.landan.cloudapps.digital
-
-# TODO: enable/disable ip filter on a per env basis. For example, a service may need the ip filter in non production envs, but not production.

--- a/tests/test-docs/example.md
+++ b/tests/test-docs/example.md
@@ -1,0 +1,42 @@
+# Commands Reference
+
+- [cli](#cli)
+- [cli hello](#cli-hello)
+
+# cli
+
+## Usage
+
+```
+Usage: cli [OPTIONS] COMMAND [ARGS]...
+```
+
+## Options
+
+- `--help <boolean>` _Defaults to False._
+  - Show this message and exit.
+
+## Commands
+
+- [`hello` ↪](#cli-hello)
+
+# cli hello
+
+[↩ Parent](#cli)
+
+## Usage
+
+```
+Usage: cli hello [OPTIONS] NAME
+```
+
+## Arguments
+
+- `name <text>`
+
+## Options
+
+- `--count <integer>` _Defaults to 1._
+  - number of greetings
+- `--help <boolean>` _Defaults to False._
+  - Show this message and exit.

--- a/tests/test_bootstrap_cli.py
+++ b/tests/test_bootstrap_cli.py
@@ -93,9 +93,9 @@ def test_make_config(tmp_path):
     """Test that make_config generates the expected directories and file
     contents."""
 
-    test_environment_manifest = Path(FIXTURES_DIR, "test_environment_manifest.yml").resolve().read_bytes()
-    production_environment_manifest = Path(FIXTURES_DIR, "production_environment_manifest.yml").read_bytes()
-    test_service_manifest = Path(FIXTURES_DIR, "test_service_manifest.yml").read_bytes()
+    test_environment_manifest = Path(FIXTURES_DIR, "test_environment_manifest.yml").read_text()
+    production_environment_manifest = Path(FIXTURES_DIR, "production_environment_manifest.yml").read_text()
+    test_service_manifest = Path(FIXTURES_DIR, "test_service_manifest.yml").read_text()
 
     switch_to_tmp_dir_and_copy_config_file(tmp_path, "test_config.yml")
     os.mkdir(f"{tmp_path}/copilot")
@@ -109,20 +109,17 @@ def test_make_config(tmp_path):
 
     assert (tmp_path / "copilot").exists()
 
-    def real_line_breaks(input: any) -> str:
-        return str(input).replace("\\n", "\n")
-
     with open(str(tmp_path / "copilot/.workspace")) as workspace:
         assert workspace.read() == "application: test-app"
 
-    with open(str(tmp_path / "copilot/environments/test/manifest.yml"), "rb") as test:
-        assert real_line_breaks(test.read()) == real_line_breaks(test_environment_manifest)
+    with open(str(tmp_path / "copilot/environments/test/manifest.yml"), "r") as test:
+        assert test.read() == test_environment_manifest
 
-    with open(str(tmp_path / "copilot/environments/production/manifest.yml"), "rb") as production:
-        assert real_line_breaks(production.read()) == real_line_breaks(production_environment_manifest)
+    with open(str(tmp_path / "copilot/environments/production/manifest.yml"), "r") as production:
+        assert production.read() == production_environment_manifest
 
-    with open(str(tmp_path / "copilot/test-service/manifest.yml"), "rb") as service:
-        assert real_line_breaks(service.read()) == real_line_breaks(test_service_manifest)
+    with open(str(tmp_path / "copilot/test-service/manifest.yml"), "r") as service:
+        assert service.read() == test_service_manifest
 
 
 @mock_sts

--- a/tests/test_check_cloudformation.py
+++ b/tests/test_check_cloudformation.py
@@ -91,5 +91,5 @@ def test_outputs_failed_results_summary(patched_prepare_cloudformation_templates
     result = CliRunner().invoke(check_cloudformation_command)
 
     assert (
-        "The CloudFormation templates failed the following checks :-(\n  - lint" in result.output
+        "The CloudFormation templates passed the following checks :-)\n  - lint\n" in result.output
     ), "The failed checks summary was not outputted"

--- a/tests/test_check_cloudformation.py
+++ b/tests/test_check_cloudformation.py
@@ -45,10 +45,10 @@ def test_prepares_cloudformation_templates(copilot_directory: Path) -> None:
         "environments/staging",
         "s3proxy",
         "s3proxy/addons",
-        "s3proxy/addons/ip-filter.yml",
+        "s3proxy/addons/appconfig-ipfilter.yml",
         "web",
         "web/addons",
-        "web/addons/ip-filter.yml",
+        "web/addons/appconfig-ipfilter.yml",
         "web/addons/my-s3-bucket.yml",
         "web/addons/my-s3-bucket-bucket-access.yml",
     ]

--- a/tests/test_copilot_cli.py
+++ b/tests/test_copilot_cli.py
@@ -229,7 +229,7 @@ invalid-entry:
                 f"{secret_name}" in result.output
             )
 
-    def test_ip_filter_policy_is_applied_to_each_service_by_default(self, fakefs):
+    def test_appconfig_ip_filter_policy_is_applied_to_each_service_by_default(self, fakefs):
         services = ["web", "web-celery"]
 
         fakefs.create_file("./storage.yml")
@@ -246,13 +246,8 @@ invalid-entry:
         result = CliRunner().invoke(cli, ["make-storage"])
 
         for service in services:
-            path = Path(f"copilot/{service}/addons/ip-filter.yml")
+            path = Path(f"copilot/{service}/addons/appconfig-ipfilter.yml")
             assert path.exists()
-
-            with open(path, "r") as fd:
-                s3_policy = yaml.safe_load(fd)
-
-            assert s3_policy["Mappings"]["ipFilterBucketNameMap"] == {"development": {"BucketName": "ipfilter-config"}}
 
         assert result.exit_code == 0
 

--- a/tests/test_storage_validation.py
+++ b/tests/test_storage_validation.py
@@ -33,7 +33,7 @@ mys3bucket:
 
     assert (
         expect_jsonschema_validation_error(storage)
-        == "'not-valid' is not one of ['rds-postgres', 'aurora-postgres', 'redis', 'opensearch', 's3', 's3-policy']"
+        == "'not-valid' is not one of ['rds-postgres', 'aurora-postgres', 'redis', 'opensearch', 's3', 's3-policy', 'appconfig-ipfilter']"
     )
 
 

--- a/utils/create_command_docs.py
+++ b/utils/create_command_docs.py
@@ -106,7 +106,7 @@ def create_docs(base_command, output):
     )
 
     with open(output, "w") as md_file:
-        md_file.write(templates["docs"].render(content))
+        md_file.write(templates.get_template("COMMANDS.md.jinja").render(content))
 
 
 @click.command()


### PR DESCRIPTION
Added an addons-template-map.yml file to determine which cloudformation files should be written on the environment and service level for each addon type.

This has simplified the make-storage command and removed the hard coded conditional logic, e.g `if storage_type == "s3-plicy": .... `

There is a failing WAF test, this appears to predate this PR. 