### PR TITLE
Allow configurable postgres secret param

### DIFF
--- a/commands/COMMANDS.md
+++ b/commands/COMMANDS.md
@@ -405,8 +405,8 @@ Usage: copilot-helper conduit tunnel [OPTIONS]
   - AWS application name
 - `--env <text>`
   - AWS environment name
-- `--db-secret <text>` _Defaults to POSTGRES._
-  - DB Credentials secret name
+- `--db-secret-name <text>` _Defaults to POSTGRES._
+  - Database credentials secret name
 - `--help <boolean>` _Defaults to False._
   - Show this message and exit.
 

--- a/commands/COMMANDS.md
+++ b/commands/COMMANDS.md
@@ -405,6 +405,8 @@ Usage: copilot-helper conduit tunnel [OPTIONS]
   - AWS application name
 - `--env <text>`
   - AWS environment name
+- `--db-secret <text>` _Defaults to POSTGRES._
+  - DB Credentials secret name
 - `--help <boolean>` _Defaults to False._
   - Show this message and exit.
 

--- a/commands/conduit_cli.py
+++ b/commands/conduit_cli.py
@@ -41,8 +41,8 @@ def get_postgres_secret(app: str, env: str, name: str = "POSTGRES"):
     return boto3.client("secretsmanager").get_secret_value(SecretId=secret_name)
 
 
-def create_task(app: str, env: str) -> None:
-    secret = get_postgres_secret(app, env)
+def create_task(app: str, env: str, db_secret: str = "POSTGRES") -> None:
+    secret = get_postgres_secret(app, env, db_secret)
     secret_arn = secret["ARN"]
     secret_json = json.loads(secret["SecretString"])
     postgres_password = secret_json["password"]
@@ -96,7 +96,8 @@ def conduit():
 @click.option("--project-profile", required=True, help="AWS account profile name")
 @click.option("--app", help="AWS application name", required=True)
 @click.option("--env", help="AWS environment name", required=True)
-def tunnel(project_profile: str, app: str, env: str) -> None:
+@click.option("--db-secret", help="DB Credentials secret name", required=True, default="POSTGRES")
+def tunnel(project_profile: str, app: str, env: str, db_secret: str) -> None:
     check_aws_conn(project_profile)
 
     cluster_arn = get_cluster_arn(app, env)
@@ -106,7 +107,7 @@ def tunnel(project_profile: str, app: str, env: str) -> None:
 
     if not is_task_running(cluster_arn):
         try:
-            create_task(app, env)
+            create_task(app, env, db_secret)
         except boto3.client("secretsmanager").exceptions.ResourceNotFoundException:
             click.secho(f"No secret found matching application {app} and environment {env}.")
             exit()

--- a/commands/conduit_cli.py
+++ b/commands/conduit_cli.py
@@ -35,8 +35,8 @@ def get_cluster_arn(app: str, env: str) -> str:
             return cluster_arn
 
 
-def get_postgres_secret(app: str, env: str):
-    secret_name = f"/copilot/{app}/{env}/secrets/POSTGRES"
+def get_postgres_secret(app: str, env: str, name: str = "POSTGRES"):
+    secret_name = f"/copilot/{app}/{env}/secrets/{name}"
 
     return boto3.client("secretsmanager").get_secret_value(SecretId=secret_name)
 

--- a/commands/conduit_cli.py
+++ b/commands/conduit_cli.py
@@ -96,8 +96,8 @@ def conduit():
 @click.option("--project-profile", required=True, help="AWS account profile name")
 @click.option("--app", help="AWS application name", required=True)
 @click.option("--env", help="AWS environment name", required=True)
-@click.option("--db-secret", help="DB Credentials secret name", required=True, default="POSTGRES")
-def tunnel(project_profile: str, app: str, env: str, db_secret: str) -> None:
+@click.option("--db-secret-name", help="Database credentials secret name", required=True, default="POSTGRES")
+def tunnel(project_profile: str, app: str, env: str, db_secret_name: str) -> None:
     check_aws_conn(project_profile)
 
     cluster_arn = get_cluster_arn(app, env)
@@ -107,7 +107,7 @@ def tunnel(project_profile: str, app: str, env: str, db_secret: str) -> None:
 
     if not is_task_running(cluster_arn):
         try:
-            create_task(app, env, db_secret)
+            create_task(app, env, db_secret_name)
         except boto3.client("secretsmanager").exceptions.ResourceNotFoundException:
             click.secho(f"No secret found matching application {app} and environment {env}.")
             exit()

--- a/commands/conduit_cli.py
+++ b/commands/conduit_cli.py
@@ -35,14 +35,14 @@ def get_cluster_arn(app: str, env: str) -> str:
             return cluster_arn
 
 
-def get_postgres_secret(app: str, env: str, name: str = "POSTGRES"):
+def get_postgres_secret(app: str, env: str, name: str):
     secret_name = f"/copilot/{app}/{env}/secrets/{name}"
 
     return boto3.client("secretsmanager").get_secret_value(SecretId=secret_name)
 
 
-def create_task(app: str, env: str, db_secret: str = "POSTGRES") -> None:
-    secret = get_postgres_secret(app, env, db_secret)
+def create_task(app: str, env: str, db_secret_name: str) -> None:
+    secret = get_postgres_secret(app, env, db_secret_name)
     secret_arn = secret["ARN"]
     secret_json = json.loads(secret["SecretString"])
     postgres_password = secret_json["password"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 119
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.20"
+version = "0.1.21"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/test_conduit_cli.py
+++ b/tests/test_conduit_cli.py
@@ -58,6 +58,26 @@ def test_get_postgres_secret(mocked_pg_secret):
     assert secret_response["Name"] == "/copilot/dbt-app/staging/secrets/POSTGRES"
 
 
+@mock_secretsmanager
+def test_get_postgres_secret_with_custom_name():
+    """Test that, given app, environment, and name strings, get_postgres_secret
+    returns the app's custom named postgres credentials."""
+    mocked_secretsmanager = boto3.client("secretsmanager")
+
+    secret_resource = {
+        "Name": "/copilot/dbt-app/staging/secrets/custom-name",
+        "Description": "A test parameter",
+        "SecretString": '{"password":"abc123","dbname":"main","engine":"postgres","port":5432,"dbInstanceIdentifier":"dbt-app-staging-addons-postgresdbinstance-blah","host":"dbt-app-staging-addons-postgresdbinstance-blah.whatever.eu-west-2.rds.amazonaws.com","username":"postgres"}',
+    }
+
+    mocked_secretsmanager.create_secret(**secret_resource)
+
+    secret_response = get_postgres_secret("dbt-app", "staging", "custom-name")
+
+    assert secret_response["SecretString"] == secret_resource["SecretString"]
+    assert secret_response["Name"] == "/copilot/dbt-app/staging/secrets/custom-name"
+
+
 def test_is_task_running_when_task_is_not_running(mocked_cluster):
     """Given an ECS Cluster ARN string, is_task_running should return False when
     the task is not running."""

--- a/tests/test_conduit_cli.py
+++ b/tests/test_conduit_cli.py
@@ -213,6 +213,36 @@ def test_tunnel_task_already_running(create_task, exec_into_task, is_task_runnin
 
 
 @mock_resourcegroupstaggingapi
+@mock_sts
+@patch("commands.conduit_cli.exec_into_task")
+@patch("commands.conduit_cli.create_task")
+def test_tunnel_task_with_custom_db_secret_name(
+    create_task, exec_into_task, alias_session, mocked_cluster, mocked_pg_secret
+):
+    """Test that, when a task is not already running, command creates and execs
+    into a task."""
+
+    cluster_arn = mocked_cluster["cluster"]["clusterArn"]
+
+    CliRunner().invoke(
+        tunnel,
+        [
+            "--project-profile",
+            "foo",
+            "--app",
+            "dbt-app",
+            "--env",
+            "staging",
+            "--db-secret-name",
+            "custom-db-secret-name",
+        ],
+    )
+
+    create_task.assert_called_once_with("dbt-app", "staging", "custom-db-secret-name")
+    exec_into_task.assert_called_once_with("dbt-app", "staging", cluster_arn)
+
+
+@mock_resourcegroupstaggingapi
 @mock_secretsmanager
 @mock_sts
 @patch("commands.conduit_cli.is_task_running", return_value=False)

--- a/tests/test_conduit_cli.py
+++ b/tests/test_conduit_cli.py
@@ -61,7 +61,7 @@ def test_get_postgres_secret(mocked_pg_secret):
 @mock_secretsmanager
 def test_get_postgres_secret_with_custom_name():
     """Test that, given app, environment, and name strings, get_postgres_secret
-    returns the app's custom named postgres credentials."""
+    returns the app's custom named Postgres credentials from Secrets Manager."""
     mocked_secretsmanager = boto3.client("secretsmanager")
 
     secret_resource = {
@@ -220,7 +220,7 @@ def test_tunnel_task_with_custom_db_secret_name(
     create_task, exec_into_task, alias_session, mocked_cluster, mocked_pg_secret
 ):
     """Test that, when a task is not already running, command creates and execs
-    into a task."""
+    into a task with optional --db-secret-name flag."""
 
     cluster_arn = mocked_cluster["cluster"]["clusterArn"]
 

--- a/tests/test_conduit_cli.py
+++ b/tests/test_conduit_cli.py
@@ -35,7 +35,7 @@ def test_create_task(subprocess_call, mocked_pg_secret):
     --app and --env flags."""
 
     expected_arn = mocked_pg_secret["ARN"]
-    create_task("dbt-app", "staging")
+    create_task("dbt-app", "staging", "POSTGRES")
 
     subprocess_call.assert_called_once_with(
         f"copilot task run -n dbtunnel --image public.ecr.aws/uktrade/tunnel --secrets DB_SECRET={expected_arn} --env-vars POSTGRES_PASSWORD=abc123 --app dbt-app --env staging",
@@ -48,7 +48,7 @@ def test_get_postgres_secret(mocked_pg_secret):
     the app's secret arn string."""
 
     expected_arn = mocked_pg_secret["ARN"]
-    secret_response = get_postgres_secret("dbt-app", "staging")
+    secret_response = get_postgres_secret("dbt-app", "staging", "POSTGRES")
 
     assert secret_response["ARN"] == expected_arn
     assert (
@@ -75,7 +75,7 @@ def test_get_postgres_secret_with_custom_name():
     secret_response = get_postgres_secret("dbt-app", "staging", "custom-name")
 
     assert secret_response["SecretString"] == secret_resource["SecretString"]
-    assert secret_response["Name"] == "/copilot/dbt-app/staging/secrets/custom-name"
+    assert secret_response["Name"] == secret_resource["Name"]
 
 
 def test_is_task_running_when_task_is_not_running(mocked_cluster):

--- a/tests/test_conduit_cli.py
+++ b/tests/test_conduit_cli.py
@@ -189,7 +189,7 @@ def test_tunnel_task_not_running(create_task, exec_into_task, alias_session, moc
 
     CliRunner().invoke(tunnel, ["--project-profile", "foo", "--app", "dbt-app", "--env", "staging"])
 
-    create_task.assert_called_once_with("dbt-app", "staging")
+    create_task.assert_called_once_with("dbt-app", "staging", "POSTGRES")
     exec_into_task.assert_called_once_with("dbt-app", "staging", cluster_arn)
 
 


### PR DESCRIPTION
## What?

Add a command line option to use a custom postgres secret when connecting via `copilot-helper conduit tunnel`.

## Why?

Some setups may involve a custom set postgres credentials name in secrets manager as this is configurable in addon stack cloudformation templates.

## How?

Add an optional flag to the `copilot-helper conduit tunnel` command and pass this through to `get_postgres_secret`, defaulting to `POSTGRES`.