### PR TITLE
DBTP-330 redis and postgres conduits

### DIFF
--- a/images/conduit/postgres/Dockerfile
+++ b/images/conduit/postgres/Dockerfile
@@ -1,7 +1,9 @@
-# Pull latest PostgreSQL Docker image
-FROM public.ecr.aws/docker/library/postgres:latest
+FROM public.ecr.aws/docker/library/debian:12-slim
 
-RUN apt-get update && apt-get install -y jq procps && apt-get clean
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y jq procps postgresql-client && \
+    apt-get clean
 
 COPY shell-profile.sh /root/.bashrc
 COPY entrypoint.sh /entrypoint.sh

--- a/images/conduit/redis/Dockerfile
+++ b/images/conduit/redis/Dockerfile
@@ -2,7 +2,7 @@ FROM public.ecr.aws/docker/library/debian:12-slim
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y jq procps lsb-release curl gpg && \
+    apt-get install -y jq procps lsb-release ca-certificates curl gpg && \
     update-ca-certificates && \
     apt-get clean
 

--- a/images/conduit/redis/Dockerfile
+++ b/images/conduit/redis/Dockerfile
@@ -1,6 +1,14 @@
-FROM public.ecr.aws/docker/library/redis:latest
+FROM public.ecr.aws/docker/library/debian:12-slim
 
-RUN apt-get update && apt-get install -y jq procps && apt-get clean
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y jq procps lsb-release curl gpg && \
+    update-ca-certificates && \
+    apt-get clean
+
+RUN curl -fsSL https://packages.redis.io/gpg | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/redis.list
+RUN apt-get update && apt-get install -y redis && apt-get clean
 
 COPY shell-profile.sh /root/.bashrc
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
# What?

* Switch all conduits to base off debian slim
* Reduce size of postgres image from 163.69MB to 62.13MB
* Install ca certificates for redis to get latest AWS ca for redis clusters

# Why?

* redis conduit was unable to connect to aws redis cluster "ssl_verify" error
* use debian slim for everything so all environments are consistent and small in size.