### PR TITLE
Fix: bind conduit tasks to app and env

### DIFF
--- a/commands/conduit_cli.py
+++ b/commands/conduit_cli.py
@@ -134,7 +134,7 @@ def connect_to_addon_client_task(app: str, env: str, cluster_arn: str, addon_nam
         if addon_client_is_running(app, env, cluster_arn, addon_name):
             running = True
             subprocess.call(
-                f"copilot task exec "
+                "copilot task exec "
                 f"--app {app} --env {env} "
                 f"--name conduit-{app}-{env}-{normalise_string(addon_name)} "
                 f"--command bash",

--- a/commands/conduit_cli.py
+++ b/commands/conduit_cli.py
@@ -99,7 +99,7 @@ def create_addon_client_task(app: str, env: str, addon_type: str, addon_name: st
     )
 
 
-def addon_client_is_running(cluster_arn: str, app: str, env: str, addon_name: str) -> bool:
+def addon_client_is_running(app: str, env: str, cluster_arn: str, addon_name: str) -> bool:
     tasks = boto3.client("ecs").list_tasks(
         cluster=cluster_arn,
         desiredStatus="RUNNING",
@@ -131,7 +131,7 @@ def connect_to_addon_client_task(app: str, env: str, cluster_arn: str, addon_nam
     while tries < 15 and not running:
         tries += 1
 
-        if addon_client_is_running(cluster_arn, app, env, addon_name):
+        if addon_client_is_running(app, env, cluster_arn, addon_name):
             running = True
             subprocess.call(
                 f"copilot task exec "
@@ -154,7 +154,7 @@ def start_conduit(app: str, env: str, addon_type: str, addon_name: str = None):
     cluster_arn = get_cluster_arn(app, env)
     addon_name = addon_name or addon_type
 
-    if not addon_client_is_running(cluster_arn, app, env, addon_name):
+    if not addon_client_is_running(app, env, cluster_arn, addon_name):
         create_addon_client_task(app, env, addon_type, addon_name)
     connect_to_addon_client_task(app, env, cluster_arn, addon_name)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.28"
+version = "0.1.29"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,7 +107,7 @@ def mock_cluster_client_task(mocked_cluster):
                 instanceIdentityDocument=mocked_instance_id_document,
             )
             mocked_task_definition_arn = mocked_ecs_client.register_task_definition(
-                family=f"copilot-conduit-{addon_type}",
+                family=f"copilot-conduit-test-application-development-{addon_type}",
                 containerDefinitions=[
                     {
                         "name": "test_container",

--- a/tests/test_conduit_cli.py
+++ b/tests/test_conduit_cli.py
@@ -171,7 +171,7 @@ def test_addon_client_is_running(mock_cluster_client_task, mocked_cluster, addon
 
     with patch("commands.conduit_cli.boto3.client", return_value=mocked_cluster_for_client):
         assert addon_client_is_running(
-            mocked_cluster_arn, "test-application", "development", addon_type
+            "test-application", "development", mocked_cluster_arn, addon_type
         )
 
 
@@ -190,7 +190,7 @@ def test_addon_client_is_running_when_no_client_task_running(
     with patch("commands.conduit_cli.boto3.client", return_value=mocked_cluster_for_client):
         assert (
             addon_client_is_running(
-                mocked_cluster_arn, "test-application", "development", addon_type
+                "test-application", "development", mocked_cluster_arn, addon_type
             )
             is False
         )
@@ -211,7 +211,7 @@ def test_addon_client_is_running_when_no_client_agent_running(
     with patch("commands.conduit_cli.boto3.client", return_value=mocked_cluster_for_client):
         assert (
             addon_client_is_running(
-                mocked_cluster_arn, "test-application", "development", addon_type
+                "test-application", "development", mocked_cluster_arn, addon_type
             )
             is False
         )
@@ -235,7 +235,7 @@ def test_connect_to_addon_client_task(addon_client_is_running, subprocess_call, 
     connect_to_addon_client_task("test-application", "development", "test-arn", addon_type)
 
     addon_client_is_running.assert_called_once_with(
-        "test-arn", "test-application", "development", addon_type
+        "test-application", "development", "test-arn", addon_type
     )
     subprocess_call.assert_called_once_with(
         f"copilot task exec --app test-application --env development "
@@ -263,7 +263,7 @@ def test_connect_to_addon_client_task_when_timeout_reached(
         connect_to_addon_client_task("test-application", "development", "test-arn", addon_type)
 
     addon_client_is_running.assert_called_with(
-        "test-arn", "test-application", "development", addon_type
+        "test-application", "development", "test-arn", addon_type
     )
     assert addon_client_is_running.call_count == 15
     subprocess_call.assert_not_called()
@@ -291,7 +291,7 @@ def test_start_conduit(
 
     get_cluster_arn.assert_called_once_with("test-application", "development")
     addon_client_is_running.assert_called_with(
-        "test-arn", "test-application", "development", addon_type
+        "test-application", "development", "test-arn", addon_type
     )
     create_addon_client_task.assert_called_once_with(
         "test-application", "development", addon_type, addon_type
@@ -348,7 +348,7 @@ def test_start_conduit_with_custom_addon_name(
 
     get_cluster_arn.assert_called_once_with("test-application", "development")
     addon_client_is_running.assert_called_with(
-        "test-arn", "test-application", "development", "custom-addon-name"
+        "test-application", "development", "test-arn", "custom-addon-name"
     )
     create_addon_client_task.assert_called_once_with(
         "test-application", "development", addon_type, "custom-addon-name"
@@ -413,7 +413,7 @@ def test_start_conduit_when_no_secret_exists(
 
     get_cluster_arn.assert_called_once_with("test-application", "development")
     addon_client_is_running.assert_called_with(
-        "test-arn", "test-application", "development", addon_type
+        "test-application", "development", "test-arn", addon_type
     )
     create_addon_client_task.assert_called_once_with(
         "test-application", "development", addon_type, addon_type
@@ -446,7 +446,7 @@ def test_start_conduit_when_no_custom_addon_secret_exists(
 
     get_cluster_arn.assert_called_once_with("test-application", "development")
     addon_client_is_running.assert_called_with(
-        "test-arn", "test-application", "development", "custom-addon-name"
+        "test-application", "development", "test-arn", "custom-addon-name"
     )
     create_addon_client_task.assert_called_once_with(
         "test-application", "development", addon_type, "custom-addon-name"
@@ -480,7 +480,7 @@ def test_start_conduit_when_addon_client_task_fails_to_start(
 
     get_cluster_arn.assert_called_once_with("test-application", "development")
     addon_client_is_running.assert_called_with(
-        "test-arn", "test-application", "development", addon_type
+        "test-application", "development", "test-arn", addon_type
     )
     create_addon_client_task.assert_called_once_with(
         "test-application", "development", addon_type, addon_type
@@ -513,7 +513,7 @@ def test_start_conduit_when_addon_client_task_is_already_running(
 
     get_cluster_arn.assert_called_once_with("test-application", "development")
     addon_client_is_running.assert_called_once_with(
-        "test-arn", "test-application", "development", addon_type
+        "test-application", "development", "test-arn", addon_type
     )
     create_addon_client_task.assert_not_called()
     connect_to_addon_client_task.assert_called_once_with(


### PR DESCRIPTION
# What?

Bind conduit tasks to a specific environment and application as well as the current addon binding.

# Why?

Currently, if I start a conduit in the dev environment and then attempt to start a conduit in the staging environment I will connect to the dev environment conduit task. This is not desirable.

# How?

Add application and environment name to the conduit task group name in ECS.