### PR TITLE
fix: opensearch resource policy ARN template

### DIFF
--- a/commands/templates/addons/env/opensearch.yml
+++ b/commands/templates/addons/env/opensearch.yml
@@ -154,7 +154,7 @@ Resources:
             AWS: '*'
           Action:
           - 'es:ESHttp*'
-          Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/{{ service.name|replace("-", "") }}*'
+          Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/{{ service.name|replace("-", "")|truncate(15) }}*'
       AdvancedSecurityOptions:
         Enabled: true
         InternalUserDatabaseEnabled: true

--- a/commands/templates/addons/env/opensearch.yml
+++ b/commands/templates/addons/env/opensearch.yml
@@ -97,7 +97,7 @@ Resources:
             AWS: '*'
           Action:
           - 'es:ESHttp*'
-          Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/{{ service.name|replace("-", "") }}*'
+          Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/{{ service.name|replace("-", "")|truncate(15) }}*'
       AdvancedSecurityOptions:
         Enabled: true
         InternalUserDatabaseEnabled: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.30"
+version = "0.1.31"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"


### PR DESCRIPTION
# What?

Fix generation of the ARN for opensearch access policy.

# Why?

The name pattern is `[truncated 15 chars of resource name]-[12 random chars]`.

# How?

Using jinja's `truncate()` filter.