### PR TITLE
DBTP-433 - Revert VPC configuration to use default configuration

### DIFF
--- a/commands/templates/addons/env/addons.parameters.yml
+++ b/commands/templates/addons/env/addons.parameters.yml
@@ -5,5 +5,5 @@
 # To be fixed under "DBTP-295 Only add the required parameters to addons.parameters.yml"
 Parameters:
   EnvironmentSecurityGroup: !Ref EnvironmentSecurityGroup
-  PrivateSubnets: !Join [ ',', [ !Ref PrivateSubnet1, !Ref PrivateSubnet2, !Ref PrivateSubnet3, ] ]
+  PrivateSubnets: !Join [ ',', [ !Ref PrivateSubnet1, !Ref PrivateSubnet2, ] ]
   VpcId: !Ref VPC

--- a/commands/templates/addons/env/opensearch.yml
+++ b/commands/templates/addons/env/opensearch.yml
@@ -184,7 +184,7 @@ Resources:
         InstanceType: !FindInMap [{{ service.prefix }}EnvScalingConfigurationMap, !Ref Env, InstanceType]
         ZoneAwarenessEnabled: true
         ZoneAwarenessConfig:
-          AvailabilityZoneCount: 3
+          AvailabilityZoneCount: 2
           #Fn::length always resolves to 1 despite there being subnets.
       VPCOptions:
         SecurityGroupIds:

--- a/commands/templates/env/manifest.yml
+++ b/commands/templates/env/manifest.yml
@@ -12,25 +12,6 @@ type: Environment
 #   vpc:
 #     id:
 
-network:
-  vpc:
-    cidr: '10.0.0.0/16'
-    subnets:
-      public:
-        - cidr: '10.0.0.0/24'
-          az: 'eu-west-2a'
-        - cidr: '10.0.1.0/24'
-          az: 'eu-west-2b'
-        - cidr: '10.0.2.0/24'
-          az: 'eu-west-2c'
-      private:
-        - cidr: '10.0.3.0/24'
-          az: 'eu-west-2a'
-        - cidr: '10.0.4.0/24'
-          az: 'eu-west-2b'
-        - cidr: '10.0.5.0/24'
-          az: 'eu-west-2c'
-
 # Configure the load balancers in your environment, once created.
 {% if certificate_arn %}
 http:

--- a/commands/templates/env/manifest.yml
+++ b/commands/templates/env/manifest.yml
@@ -7,11 +7,6 @@
 name: {{ name }}
 type: Environment
 
-# Import your own VPC and subnets or configure how they should be created.
-# network:
-#   vpc:
-#     id:
-
 # Configure the load balancers in your environment, once created.
 {% if certificate_arn %}
 http:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.32"
+version = "0.1.33"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/fixtures/make_addons/config/copilot/environments/development/manifest.yml
+++ b/tests/fixtures/make_addons/config/copilot/environments/development/manifest.yml
@@ -7,11 +7,6 @@
 name: development
 type: Environment
 
-# Import your own VPC and subnets or configure how they should be created.
-# network:
-#   vpc:
-#     id:
-
 # Configure the load balancers in your environment, once created.
 
 http:

--- a/tests/fixtures/make_addons/config/copilot/environments/development/manifest.yml
+++ b/tests/fixtures/make_addons/config/copilot/environments/development/manifest.yml
@@ -12,25 +12,6 @@ type: Environment
 #   vpc:
 #     id:
 
-network:
-  vpc:
-    cidr: '10.0.0.0/16'
-    subnets:
-      public:
-        - cidr: '10.0.0.0/24'
-          az: 'eu-west-2a'
-        - cidr: '10.0.1.0/24'
-          az: 'eu-west-2b'
-        - cidr: '10.0.2.0/24'
-          az: 'eu-west-2c'
-      private:
-        - cidr: '10.0.3.0/24'
-          az: 'eu-west-2a'
-        - cidr: '10.0.4.0/24'
-          az: 'eu-west-2b'
-        - cidr: '10.0.5.0/24'
-          az: 'eu-west-2c'
-
 # Configure the load balancers in your environment, once created.
 
 http:

--- a/tests/fixtures/make_addons/expected/environments/addons/addons.parameters.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/addons.parameters.yml
@@ -5,5 +5,5 @@
 # To be fixed under "DBTP-295 Only add the required parameters to addons.parameters.yml"
 Parameters:
   EnvironmentSecurityGroup: !Ref EnvironmentSecurityGroup
-  PrivateSubnets: !Join [ ',', [ !Ref PrivateSubnet1, !Ref PrivateSubnet2, !Ref PrivateSubnet3, ] ]
+  PrivateSubnets: !Join [ ',', [ !Ref PrivateSubnet1, !Ref PrivateSubnet2, ] ]
   VpcId: !Ref VPC

--- a/tests/fixtures/make_addons/expected/environments/addons/my-opensearch-with-a-long-name.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-opensearch-with-a-long-name.yml
@@ -184,7 +184,7 @@ Resources:
         InstanceType: !FindInMap [myOpensearchWithALongNameEnvScalingConfigurationMap, !Ref Env, InstanceType]
         ZoneAwarenessEnabled: true
         ZoneAwarenessConfig:
-          AvailabilityZoneCount: 3
+          AvailabilityZoneCount: 2
           #Fn::length always resolves to 1 despite there being subnets.
       VPCOptions:
         SecurityGroupIds:

--- a/tests/fixtures/make_addons/expected/environments/addons/my-opensearch.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-opensearch.yml
@@ -184,7 +184,7 @@ Resources:
         InstanceType: !FindInMap [myOpensearchEnvScalingConfigurationMap, !Ref Env, InstanceType]
         ZoneAwarenessEnabled: true
         ZoneAwarenessConfig:
-          AvailabilityZoneCount: 3
+          AvailabilityZoneCount: 2
           #Fn::length always resolves to 1 despite there being subnets.
       VPCOptions:
         SecurityGroupIds:

--- a/tests/fixtures/production_environment_manifest.yml
+++ b/tests/fixtures/production_environment_manifest.yml
@@ -12,25 +12,6 @@ type: Environment
 #   vpc:
 #     id:
 
-network:
-  vpc:
-    cidr: '10.0.0.0/16'
-    subnets:
-      public:
-        - cidr: '10.0.0.0/24'
-          az: 'eu-west-2a'
-        - cidr: '10.0.1.0/24'
-          az: 'eu-west-2b'
-        - cidr: '10.0.2.0/24'
-          az: 'eu-west-2c'
-      private:
-        - cidr: '10.0.3.0/24'
-          az: 'eu-west-2a'
-        - cidr: '10.0.4.0/24'
-          az: 'eu-west-2b'
-        - cidr: '10.0.5.0/24'
-          az: 'eu-west-2c'
-
 # Configure the load balancers in your environment, once created.
 
 http:

--- a/tests/fixtures/production_environment_manifest.yml
+++ b/tests/fixtures/production_environment_manifest.yml
@@ -7,11 +7,6 @@
 name: production
 type: Environment
 
-# Import your own VPC and subnets or configure how they should be created.
-# network:
-#   vpc:
-#     id:
-
 # Configure the load balancers in your environment, once created.
 
 http:

--- a/tests/fixtures/test_environment_manifest.yml
+++ b/tests/fixtures/test_environment_manifest.yml
@@ -7,11 +7,6 @@
 name: test
 type: Environment
 
-# Import your own VPC and subnets or configure how they should be created.
-# network:
-#   vpc:
-#     id:
-
 # Configure the load balancers in your environment, once created.
 
 http:

--- a/tests/fixtures/test_environment_manifest.yml
+++ b/tests/fixtures/test_environment_manifest.yml
@@ -12,25 +12,6 @@ type: Environment
 #   vpc:
 #     id:
 
-network:
-  vpc:
-    cidr: '10.0.0.0/16'
-    subnets:
-      public:
-        - cidr: '10.0.0.0/24'
-          az: 'eu-west-2a'
-        - cidr: '10.0.1.0/24'
-          az: 'eu-west-2b'
-        - cidr: '10.0.2.0/24'
-          az: 'eu-west-2c'
-      private:
-        - cidr: '10.0.3.0/24'
-          az: 'eu-west-2a'
-        - cidr: '10.0.4.0/24'
-          az: 'eu-west-2b'
-        - cidr: '10.0.5.0/24'
-          az: 'eu-west-2c'
-
 # Configure the load balancers in your environment, once created.
 
 http:


### PR DESCRIPTION
## Context

- Revert to using the default VPC configuration
  - The default is 2 public and 2 private subnets.
- Update version from `0.1.32` -> `0.1.33`

## Additional information

Jira ticket - https://uktrade.atlassian.net/browse/DBTP-433