### PR TITLE
fix: truncate opensearch names under 20 chars

### DIFF
--- a/commands/templates/addons/env/opensearch.yml
+++ b/commands/templates/addons/env/opensearch.yml
@@ -97,7 +97,7 @@ Resources:
             AWS: '*'
           Action:
           - 'es:ESHttp*'
-          Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/{{ service.name|replace("-", "")|truncate(15, False, '') }}*'
+          Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/{{ (service.name|replace("-", ""))[:15] }}*'
       AdvancedSecurityOptions:
         Enabled: true
         InternalUserDatabaseEnabled: true
@@ -154,7 +154,7 @@ Resources:
             AWS: '*'
           Action:
           - 'es:ESHttp*'
-          Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/{{ service.name|replace("-", "")|truncate(15, False, '') }}*'
+          Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/{{ (service.name|replace("-", ""))[:15] }}*'
       AdvancedSecurityOptions:
         Enabled: true
         InternalUserDatabaseEnabled: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.33"
+version = "0.1.34"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/fixtures/make_addons/expected/environments/addons/my-opensearch-longer.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-opensearch-longer.yml
@@ -17,7 +17,7 @@ Parameters:
     Type: String
 
 Mappings:
-  myOpensearchWithALongNameEnvScalingConfigurationMap:
+  myOpensearchLongerEnvScalingConfigurationMap:
     
     development:
       EngineVersion: '2.3'
@@ -27,7 +27,7 @@ Mappings:
       VolumeSize: 200
     
 
-  myOpensearchWithALongNameEngineVersionMap:
+  myOpensearchLongerEngineVersionMap:
     '1.0':
       EngineVersion: 'OpenSearch_1.0'
     '1.1':
@@ -40,16 +40,16 @@ Mappings:
       EngineVersion: 'OpenSearch_2.3'
 
 Conditions:
-  myOpensearchWithALongNameDisableHA: !Equals [!FindInMap [myOpensearchWithALongNameEnvScalingConfigurationMap, !Ref Env, InstanceCount], 1]
-  myOpensearchWithALongNameEnableHA: !Not [Condition: myOpensearchWithALongNameDisableHA]
+  myOpensearchLongerDisableHA: !Equals [!FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, InstanceCount], 1]
+  myOpensearchLongerEnableHA: !Not [Condition: myOpensearchLongerDisableHA]
 
 Resources:
-  myOpensearchWithALongNameOpenSearchSecret:
+  myOpensearchLongerOpenSearchSecret:
     Metadata:
       'aws:copilot:description': 'A Secrets Manager secret to store your OS credentials'
     Type: AWS::SecretsManager::Secret
     Properties:
-      Name: !Sub '/copilot/${App}/${Env}/secrets/MY_OPENSEARCH_WITH_A_LONG_NAME'
+      Name: !Sub '/copilot/${App}/${Env}/secrets/MY_OPENSEARCH_LONGER'
       Description: !Sub OpenSearch main user secret for ${AWS::StackName}
       GenerateSecretString:
         SecretStringTemplate: '{"username": "opensearch"}'
@@ -60,34 +60,34 @@ Resources:
         PasswordLength: 20
   # Security group to add OS to the VPC,
   # and to allow the Fargate containers to talk to OS
-  myOpensearchWithALongNameOpenSearchSecurityGroup:
+  myOpensearchLongerOpenSearchSecurityGroup:
     Metadata:
       'aws:copilot:description': 'A security group to access OS'
     Type: AWS::EC2::SecurityGroup
     Properties:
-      GroupDescription: 'The Security Group for my-opensearch-with-a-long-name to access OpenSearch.'
+      GroupDescription: 'The Security Group for my-opensearch-longer to access OpenSearch.'
       VpcId: !Ref VpcId
       Tags:
         - Key: Name
-          Value: !Sub 'copilot-${App}-${Env}-my-opensearch-with-a-long-name-OpenSearch-SecurityGroup'
+          Value: !Sub 'copilot-${App}-${Env}-my-opensearch-longer-OpenSearch-SecurityGroup'
 
   # Enable ingress from other ECS services created within the environment.
-  myOpensearchWithALongNameOpenSearchIngress:
+  myOpensearchLongerOpenSearchIngress:
     Metadata:
       'aws:copilot:description': 'Allow ingress from containers in my application to the OpenSearch cluster'
     Type: AWS::EC2::SecurityGroupIngress
     Properties:
       Description: Ingress Security Group from Fargate containers
-      GroupId: !Ref 'myOpensearchWithALongNameOpenSearchSecurityGroup'
+      GroupId: !Ref 'myOpensearchLongerOpenSearchSecurityGroup'
       IpProtocol: tcp
       FromPort: 443
       ToPort: 443
       SourceSecurityGroupId: !Ref EnvironmentSecurityGroup
 
   # Single opensearch instance
-  myOpensearchWithALongNameOpenSearchDomain:
+  myOpensearchLongerOpenSearchDomain:
     Type: 'AWS::OpenSearchService::Domain'
-    Condition: myOpensearchWithALongNameDisableHA
+    Condition: myOpensearchLongerDisableHA
     Properties:
       AccessPolicies:
         Version: '2012-10-17'
@@ -97,21 +97,21 @@ Resources:
             AWS: '*'
           Action:
           - 'es:ESHttp*'
-          Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/myopensearchwit*'
+          Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/myopensearchlon*'
       AdvancedSecurityOptions:
         Enabled: true
         InternalUserDatabaseEnabled: true
         MasterUserOptions:
           MasterUserName:
-            !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchWithALongNameOpenSearchSecret, ":SecretString:username}}" ]]
+            !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchLongerOpenSearchSecret, ":SecretString:username}}" ]]
           MasterUserPassword:
-            !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchWithALongNameOpenSearchSecret, ":SecretString:password}}" ]]
+            !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchLongerOpenSearchSecret, ":SecretString:password}}" ]]
       DomainEndpointOptions:
         EnforceHTTPS: true
         TLSSecurityPolicy: 'Policy-Min-TLS-1-2-2019-07'
       EngineVersion: !FindInMap
-        - myOpensearchWithALongNameEngineVersionMap
-        - !FindInMap [myOpensearchWithALongNameEnvScalingConfigurationMap, !Ref Env, EngineVersion]
+        - myOpensearchLongerEngineVersionMap
+        - !FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, EngineVersion]
         - EngineVersion
       NodeToNodeEncryptionOptions:
         Enabled: true
@@ -119,32 +119,32 @@ Resources:
         Enabled: true
       EBSOptions:
         EBSEnabled: true
-        VolumeSize: !FindInMap [myOpensearchWithALongNameEnvScalingConfigurationMap, !Ref Env, VolumeSize]
+        VolumeSize: !FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, VolumeSize]
         VolumeType: gp2
       ClusterConfig:
         DedicatedMasterEnabled: false
-        InstanceCount: !FindInMap [myOpensearchWithALongNameEnvScalingConfigurationMap, !Ref Env, InstanceCount]
-        InstanceType: !FindInMap [myOpensearchWithALongNameEnvScalingConfigurationMap, !Ref Env, InstanceType]
+        InstanceCount: !FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, InstanceCount]
+        InstanceType: !FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, InstanceType]
         ZoneAwarenessEnabled: false
       VPCOptions:
         SecurityGroupIds:
-          - !Ref myOpensearchWithALongNameOpenSearchSecurityGroup
+          - !Ref myOpensearchLongerOpenSearchSecurityGroup
         SubnetIds:
           - !Select [0, !Split [ ',', !Ref PrivateSubnets ] ]
       SoftwareUpdateOptions:
         AutoSoftwareUpdateEnabled: true
       Tags:
         - Key: Name
-          Value: !Sub 'copilot-${App}-${Env}-my-opensearch-with-a-long-name-OpenSearch-Domain'
+          Value: !Sub 'copilot-${App}-${Env}-my-opensearch-longer-OpenSearch-Domain'
         - Key: 'Copilot-Application'
           Value: !Sub ${App}
         - Key: 'Copilot-Environment'
           Value: !Sub ${Env}
 
   # An opensearch cluster
-  myOpensearchWithALongNameOpenSearchDomainHA:
+  myOpensearchLongerOpenSearchDomainHA:
     Type: 'AWS::OpenSearchService::Domain'
-    Condition: myOpensearchWithALongNameEnableHA
+    Condition: myOpensearchLongerEnableHA
     Properties:
       AccessPolicies:
         Version: '2012-10-17'
@@ -154,21 +154,21 @@ Resources:
             AWS: '*'
           Action:
           - 'es:ESHttp*'
-          Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/myopensearchwit*'
+          Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/myopensearchlon*'
       AdvancedSecurityOptions:
         Enabled: true
         InternalUserDatabaseEnabled: true
         MasterUserOptions:
           MasterUserName:
-            !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchWithALongNameOpenSearchSecret, ":SecretString:username}}" ]]
+            !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchLongerOpenSearchSecret, ":SecretString:username}}" ]]
           MasterUserPassword:
-            !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchWithALongNameOpenSearchSecret, ":SecretString:password}}" ]]
+            !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchLongerOpenSearchSecret, ":SecretString:password}}" ]]
       DomainEndpointOptions:
         EnforceHTTPS: true
         TLSSecurityPolicy: 'Policy-Min-TLS-1-2-2019-07'
       EngineVersion: !FindInMap
-        - myOpensearchWithALongNameEngineVersionMap
-        - !FindInMap [myOpensearchWithALongNameEnvScalingConfigurationMap, !Ref Env, EngineVersion]
+        - myOpensearchLongerEngineVersionMap
+        - !FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, EngineVersion]
         - EngineVersion
       NodeToNodeEncryptionOptions:
         Enabled: true
@@ -176,40 +176,40 @@ Resources:
         Enabled: true
       EBSOptions:
         EBSEnabled: true
-        VolumeSize: !FindInMap [myOpensearchWithALongNameEnvScalingConfigurationMap, !Ref Env, VolumeSize]
+        VolumeSize: !FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, VolumeSize]
         VolumeType: gp2
       ClusterConfig:
-        DedicatedMasterEnabled: !FindInMap [myOpensearchWithALongNameEnvScalingConfigurationMap, !Ref Env, DedicatedMaster]
-        InstanceCount: !FindInMap [myOpensearchWithALongNameEnvScalingConfigurationMap, !Ref Env, InstanceCount]
-        InstanceType: !FindInMap [myOpensearchWithALongNameEnvScalingConfigurationMap, !Ref Env, InstanceType]
+        DedicatedMasterEnabled: !FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, DedicatedMaster]
+        InstanceCount: !FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, InstanceCount]
+        InstanceType: !FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, InstanceType]
         ZoneAwarenessEnabled: true
         ZoneAwarenessConfig:
           AvailabilityZoneCount: 2
           #Fn::length always resolves to 1 despite there being subnets.
       VPCOptions:
         SecurityGroupIds:
-          - !Ref myOpensearchWithALongNameOpenSearchSecurityGroup
+          - !Ref myOpensearchLongerOpenSearchSecurityGroup
         SubnetIds: !Split [ ",", !Ref PrivateSubnets ]
       SoftwareUpdateOptions:
         AutoSoftwareUpdateEnabled: true
       Tags:
         - Key: Name
-          Value: !Sub 'copilot-${App}-${Env}-my-opensearch-with-a-long-name-OpenSearch-Domain'
+          Value: !Sub 'copilot-${App}-${Env}-my-opensearch-longer-OpenSearch-Domain'
         - Key: 'Copilot-Application'
           Value: !Sub ${App}
         - Key: 'Copilot-Environment'
           Value: !Sub ${Env}
 
-  myOpensearchWithALongNameOpenSearchEndpointConfigParam:
+  myOpensearchLongerOpenSearchEndpointConfigParam:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: !Sub "/copilot/${App}/${Env}/secrets/MY_OPENSEARCH_WITH_A_LONG_NAME"
+      Name: !Sub "/copilot/${App}/${Env}/secrets/MY_OPENSEARCH_LONGER"
       Type: String
       Value: !Sub
         - "https://${username}:${password}@${url}"
         - url: !If
-            - myOpensearchWithALongNameEnableHA
-            - !GetAtt myOpensearchWithALongNameOpenSearchDomainHA.DomainEndpoint
-            - !GetAtt myOpensearchWithALongNameOpenSearchDomain.DomainEndpoint
-          username: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchWithALongNameOpenSearchSecret, ":SecretString:username}}" ]]
-          password: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchWithALongNameOpenSearchSecret, ":SecretString:password}}" ]]
+            - myOpensearchLongerEnableHA
+            - !GetAtt myOpensearchLongerOpenSearchDomainHA.DomainEndpoint
+            - !GetAtt myOpensearchLongerOpenSearchDomain.DomainEndpoint
+          username: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchLongerOpenSearchSecret, ":SecretString:username}}" ]]
+          password: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchLongerOpenSearchSecret, ":SecretString:password}}" ]]

--- a/tests/fixtures/make_addons/opensearch_addons.yml
+++ b/tests/fixtures/make_addons/opensearch_addons.yml
@@ -10,7 +10,9 @@ my-opensearch:
       # supported engine versions as of 06/2023: 2.5, 2.3, 1.3, 1.2, 1.1, 1.0
       engine: "2.3"
 
-my-opensearch-with-a-long-name:
+# This name is meant to be 18 characters without hyphens,
+# this tests access policy generation.
+my-opensearch-longer:
   type: opensearch
 
   environments:

--- a/tests/test_copilot_cli.py
+++ b/tests/test_copilot_cli.py
@@ -79,7 +79,7 @@ class TestMakeAddonCommand:
                 "opensearch_addons.yml",
                 [
                     "my-opensearch.yml",
-                    "my-opensearch-with-a-long-name.yml",
+                    "my-opensearch-longer.yml",
                     "addons.parameters.yml",
                 ],
                 ["appconfig-ipfilter.yml"],


### PR DESCRIPTION
# What?

Fix addon template access policy generation for opensearch.

#Why?

Currently truncate will only truncate to 15 chars if the string is more than 20 chars in length, we need it to hard limit to 15 chars.

#How?

Use an array slice to truncate instead of truncate.