### PR TITLE
fix: more url invalid symbols for passwords in urls

### DIFF
--- a/commands/templates/addons/env/aurora-postgres.yml
+++ b/commands/templates/addons/env/aurora-postgres.yml
@@ -76,7 +76,7 @@ Resources:
         ExcludePunctuation: true
         IncludeSpace: false
         PasswordLength: 16
-        ExcludeCharacters: '"@/\;='
+        ExcludeCharacters: '"@/\;=?&`><:|#'
 
   {{ service.prefix }}DBClusterParameterGroup:
     Metadata:

--- a/commands/templates/addons/env/opensearch.yml
+++ b/commands/templates/addons/env/opensearch.yml
@@ -58,7 +58,7 @@ Resources:
         RequireEachIncludedType: true
         IncludeSpace: false
         PasswordLength: 20
-        ExcludeCharacters: '"@/\;='
+        ExcludeCharacters: '"@/\;=?&`><:|#'
   # Security group to add OS to the VPC,
   # and to allow the Fargate containers to talk to OS
   {{ service.prefix }}OpenSearchSecurityGroup:

--- a/commands/templates/addons/env/rds-postgres.yml
+++ b/commands/templates/addons/env/rds-postgres.yml
@@ -103,7 +103,7 @@ Resources:
         ExcludePunctuation: true
         IncludeSpace: false
         PasswordLength: 16
-        ExcludeCharacters: '"@/\;='
+        ExcludeCharacters: '"@/\;=?&`><:|#'
 
   {{ service.prefix }}SecretRDSAttachment:
     Type: AWS::SecretsManager::SecretTargetAttachment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.37"
+version = "0.1.38"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/fixtures/make_addons/expected/environments/addons/my-aurora-db.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-aurora-db.yml
@@ -76,7 +76,7 @@ Resources:
         ExcludePunctuation: true
         IncludeSpace: false
         PasswordLength: 16
-        ExcludeCharacters: '"@/\;='
+        ExcludeCharacters: '"@/\;=?&`><:|#'
 
   myAuroraDbDBClusterParameterGroup:
     Metadata:

--- a/tests/fixtures/make_addons/expected/environments/addons/my-opensearch-longer.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-opensearch-longer.yml
@@ -58,7 +58,7 @@ Resources:
         RequireEachIncludedType: true
         IncludeSpace: false
         PasswordLength: 20
-        ExcludeCharacters: '"@/\;='
+        ExcludeCharacters: '"@/\;=?&`><:|#'
   # Security group to add OS to the VPC,
   # and to allow the Fargate containers to talk to OS
   myOpensearchLongerOpenSearchSecurityGroup:

--- a/tests/fixtures/make_addons/expected/environments/addons/my-opensearch.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-opensearch.yml
@@ -58,7 +58,7 @@ Resources:
         RequireEachIncludedType: true
         IncludeSpace: false
         PasswordLength: 20
-        ExcludeCharacters: '"@/\;='
+        ExcludeCharacters: '"@/\;=?&`><:|#'
   # Security group to add OS to the VPC,
   # and to allow the Fargate containers to talk to OS
   myOpensearchOpenSearchSecurityGroup:

--- a/tests/fixtures/make_addons/expected/environments/addons/my-rds-db.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-rds-db.yml
@@ -103,7 +103,7 @@ Resources:
         ExcludePunctuation: true
         IncludeSpace: false
         PasswordLength: 16
-        ExcludeCharacters: '"@/\;='
+        ExcludeCharacters: '"@/\;=?&`><:|#'
 
   myRdsDbSecretRDSAttachment:
     Type: AWS::SecretsManager::SecretTargetAttachment


### PR DESCRIPTION
Subsequent to #158 we found a number of other symbols that are invalid in URLs: 

```
?&`><:|#
```

This PR adds those to all addons templates that need them. 