### PR TITLE
Added further characters to exclude from passwords

### DIFF
--- a/commands/templates/addons/env/aurora-postgres.yml
+++ b/commands/templates/addons/env/aurora-postgres.yml
@@ -76,7 +76,7 @@ Resources:
         ExcludePunctuation: true
         IncludeSpace: false
         PasswordLength: 16
-        ExcludeCharacters: '"@/\;=?&`><:|#'
+        ExcludeCharacters: '[]{}()"@/\;=?&`><:|#'
 
   {{ service.prefix }}DBClusterParameterGroup:
     Metadata:

--- a/commands/templates/addons/env/opensearch.yml
+++ b/commands/templates/addons/env/opensearch.yml
@@ -58,7 +58,7 @@ Resources:
         RequireEachIncludedType: true
         IncludeSpace: false
         PasswordLength: 20
-        ExcludeCharacters: '"@/\;=?&`><:|#'
+        ExcludeCharacters: '[]{}()"@/\;=?&`><:|#'
   # Security group to add OS to the VPC,
   # and to allow the Fargate containers to talk to OS
   {{ service.prefix }}OpenSearchSecurityGroup:

--- a/commands/templates/addons/env/rds-postgres.yml
+++ b/commands/templates/addons/env/rds-postgres.yml
@@ -103,7 +103,7 @@ Resources:
         ExcludePunctuation: true
         IncludeSpace: false
         PasswordLength: 16
-        ExcludeCharacters: '"@/\;=?&`><:|#'
+        ExcludeCharacters: '[]{}()"@/\;=?&`><:|#'
 
   {{ service.prefix }}SecretRDSAttachment:
     Type: AWS::SecretsManager::SecretTargetAttachment

--- a/tests/fixtures/make_addons/expected/environments/addons/my-aurora-db.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-aurora-db.yml
@@ -76,7 +76,7 @@ Resources:
         ExcludePunctuation: true
         IncludeSpace: false
         PasswordLength: 16
-        ExcludeCharacters: '"@/\;=?&`><:|#'
+        ExcludeCharacters: '[]{}()"@/\;=?&`><:|#'
 
   myAuroraDbDBClusterParameterGroup:
     Metadata:

--- a/tests/fixtures/make_addons/expected/environments/addons/my-opensearch-longer.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-opensearch-longer.yml
@@ -58,7 +58,7 @@ Resources:
         RequireEachIncludedType: true
         IncludeSpace: false
         PasswordLength: 20
-        ExcludeCharacters: '"@/\;=?&`><:|#'
+        ExcludeCharacters: '[]{}()"@/\;=?&`><:|#'
   # Security group to add OS to the VPC,
   # and to allow the Fargate containers to talk to OS
   myOpensearchLongerOpenSearchSecurityGroup:

--- a/tests/fixtures/make_addons/expected/environments/addons/my-opensearch.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-opensearch.yml
@@ -58,7 +58,7 @@ Resources:
         RequireEachIncludedType: true
         IncludeSpace: false
         PasswordLength: 20
-        ExcludeCharacters: '"@/\;=?&`><:|#'
+        ExcludeCharacters: '[]{}()"@/\;=?&`><:|#'
   # Security group to add OS to the VPC,
   # and to allow the Fargate containers to talk to OS
   myOpensearchOpenSearchSecurityGroup:

--- a/tests/fixtures/make_addons/expected/environments/addons/my-rds-db.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-rds-db.yml
@@ -103,7 +103,7 @@ Resources:
         ExcludePunctuation: true
         IncludeSpace: false
         PasswordLength: 16
-        ExcludeCharacters: '"@/\;=?&`><:|#'
+        ExcludeCharacters: '[]{}()"@/\;=?&`><:|#'
 
   myRdsDbSecretRDSAttachment:
     Type: AWS::SecretsManager::SecretTargetAttachment


### PR DESCRIPTION
The ExcludeCharacters field needed updating, as python's urlparse function was failing to parse opensearch URLs that contain the generated password. In this case, it was square brackets that were causing the issue, but i have excluded parentheses and braces as well to ensure we don't hit this issue again.