### PR TITLE
remove multiaz option from aurora template

### DIFF
--- a/dbt_copilot_helper/schemas/addons-schema.json
+++ b/dbt_copilot_helper/schemas/addons-schema.json
@@ -292,9 +292,6 @@
             "max-capacity": {
                "type": "number",
                "minimum": 0.5
-            },
-            "replicas": {
-               "type": "integer"
             }
          },
          "additionalProperties": false

--- a/dbt_copilot_helper/templates/addons/env/aurora-postgres.yml
+++ b/dbt_copilot_helper/templates/addons/env/aurora-postgres.yml
@@ -31,7 +31,6 @@ Mappings:
     {{ environment_name }}:
       DBMinCapacity: {{ config.min_capacity }}
       DBMaxCapacity: {{ config.max_capacity }}
-      MultiAZ: {% if config.replicas %}true{% else %}false{% endif %}
 {% endfor %}
 
 Resources:
@@ -127,7 +126,6 @@ Resources:
       DBInstanceClass: db.serverless
       EnablePerformanceInsights: true
       Engine: 'aurora-postgresql'
-      MultiAZ: !FindInMap [{{ service.prefix }}EnvScalingConfigurationMap, !Ref Env, MultiAZ]
       PromotionTier: 1
       AvailabilityZone: !Select
         - 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.49"
+version = "0.1.50"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/fixtures/make_addons/expected/environments/addons/my-aurora-db.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-aurora-db.yml
@@ -31,7 +31,6 @@ Mappings:
     development:
       DBMinCapacity: 0.5
       DBMaxCapacity: 8
-      MultiAZ: false
 
 
 Resources:
@@ -127,7 +126,6 @@ Resources:
       DBInstanceClass: db.serverless
       EnablePerformanceInsights: true
       Engine: 'aurora-postgresql'
-      MultiAZ: !FindInMap [myAuroraDbEnvScalingConfigurationMap, !Ref Env, MultiAZ]
       PromotionTier: 1
       AvailabilityZone: !Select
         - 0


### PR DESCRIPTION
From the [docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbinstance.html): "Not applicable. Amazon Aurora storage is replicated across all of the Availability Zones and doesn't require the MultiAZ option to be set."