### PR TITLE
Conduit order of connection strings

### DIFF
--- a/dbt_copilot_helper/commands/conduit.py
+++ b/dbt_copilot_helper/commands/conduit.py
@@ -76,15 +76,15 @@ def get_connection_secret_arn(app: str, env: str, name: str) -> str:
     ssm = boto3.client("ssm")
 
     try:
-        return secrets_manager.describe_secret(SecretId=connection_secret_id)["ARN"]
-    except secrets_manager.exceptions.ResourceNotFoundException:
-        pass
-
-    try:
         return ssm.get_parameter(Name=connection_secret_id, WithDecryption=False)["Parameter"][
             "ARN"
         ]
     except ssm.exceptions.ParameterNotFound:
+        pass
+
+    try:
+        return secrets_manager.describe_secret(SecretId=connection_secret_id)["ARN"]
+    except secrets_manager.exceptions.ResourceNotFoundException:
         pass
 
     raise SecretNotFoundConduitError(name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.55"
+version = "0.1.56"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/test_command_conduit.py
+++ b/tests/test_command_conduit.py
@@ -58,6 +58,7 @@ def test_get_cluster_arn_when_there_is_no_cluster():
 
 
 @mock_secretsmanager
+@mock_ssm
 def test_get_connection_secret_arn_from_secrets_manager():
     """Test that, given app, environment and secret name strings,
     get_connection_secret_arn returns an ARN from secrets manager."""
@@ -75,7 +76,6 @@ def test_get_connection_secret_arn_from_secrets_manager():
     )
 
 
-@mock_secretsmanager
 @mock_ssm
 def test_get_connection_secret_arn_from_parameter_store():
     """Test that, given app, environment and secret name strings,


### PR DESCRIPTION
Currently secrets manager is checked first, which runs into issue because the opensearch addons have both a secrets manager and parameter store variable. The secret is json storing only username and password whereas the parameter store has the actual connection string.