### PR TITLE
Fix: allow setting opensearch volume size

### DIFF
--- a/dbt_copilot_helper/commands/copilot.py
+++ b/dbt_copilot_helper/commands/copilot.py
@@ -49,6 +49,11 @@ def _validate_and_normalise_config(config_file):
     def _lookup_plan(addon_type, env_conf):
         plan = env_conf.pop("plan", None)
         conf = addon_plans[addon_type][plan] if plan else {}
+
+        # Make a copy of the addon plan config so subsequent
+        # calls do not override the root object
+        conf = conf.copy()
+
         conf.update(env_conf)
 
         return conf

--- a/dbt_copilot_helper/schemas/addons-schema.json
+++ b/dbt_copilot_helper/schemas/addons-schema.json
@@ -338,6 +338,11 @@
             },
             "engine": {
                "$ref": "#/definitions/opensearch-engine-versions"
+            },
+            "volume_size": {
+               "type": "integer",
+               "minimum": 10,
+               "exclusiveMaximum": 512
             }
          },
          "additionalProperties": false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.59"
+version = "0.1.60"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/fixtures/make_addons/expected/environments/addons/my-opensearch.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-opensearch.yml
@@ -24,7 +24,7 @@ Mappings:
       InstanceType: 't3.medium.search'
       InstanceCount: 1
       DedicatedMaster: false
-      VolumeSize: 200
+      VolumeSize: 40
     
 
   myOpensearchEngineVersionMap:

--- a/tests/fixtures/make_addons/opensearch_addons.yml
+++ b/tests/fixtures/make_addons/opensearch_addons.yml
@@ -9,6 +9,7 @@ my-opensearch:
 
       # supported engine versions as of 06/2023: 2.5, 2.3, 1.3, 1.2, 1.1, 1.0
       engine: "2.3"
+      volume_size: 40
 
 # This name is meant to be 18 characters without hyphens,
 # this tests access policy generation.


### PR DESCRIPTION
- Allow overriding plan default volume size for opensearch in `addons.yml`.
- Fix a bug where overriding the addon plan also overrode the plans values for subsequent addons of the same type.