### PR TITLE
DBTP-430 Update Paketo builder and run images

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,7 +11,7 @@ phases:
     - echo Logging in to AWS ECR...
     - aws --version
     - aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/uktrade
-    - BUILDER_IMAGE_TAG=$(curl -s 'https://hub.docker.com/v2/repositories/paketobuildpacks/builder/tags?name=-full&page_size=1' | jq -r '.results[].name')
+    - BUILDER_IMAGE_TAG=curl -s 'https://hub.docker.com/v2/repositories/paketobuildpacks/builder-jammy-full/tags?page_size=1' | jq -r '.results[].name' 
     - BUILDER_REPOSITORY_URI=public.ecr.aws/uktrade/paketobuildpacks/builder
     - LIFECYCLE_REPOSITORY_URI=public.ecr.aws/uktrade/buildpacksio/lifecycle
     - RUN_REPOSITORY_URI=public.ecr.aws/uktrade/paketobuildpacks/run
@@ -28,8 +28,8 @@ phases:
     - docker tag buildpacksio/lifecycle:$LIFECYCLE_IMAGE_TAG $LIFECYCLE_REPOSITORY_URI:$LIFECYCLE_IMAGE_TAG
     - docker tag buildpacksio/lifecycle:$LIFECYCLE_IMAGE_TAG $LIFECYCLE_REPOSITORY_URI:latest
     - echo Pulling the Run Docker image...
-    - docker pull paketobuildpacks/run:full-cnb
-    - docker tag paketobuildpacks/run:full-cnb $RUN_REPOSITORY_URI:full-cnb
+    - docker pull paketobuildpacks/run-jammy-full:latest
+    - docker tag paketobuildpacks/run-jammy-full:latest $RUN_REPOSITORY_URI:latest
   post_build:
     commands:
     - echo Pull completed on `date`


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/DBTP-430

The previous builder image was archived and not receiving updates, meaning ecr images built with it contained increasing numbers of vulnerabilities.