### PR TITLE
DBTP-497 BSI 6.1: RDS not encrypted using customer keys

### DIFF
--- a/dbt_copilot_helper/templates/addons/env/aurora-postgres.yml
+++ b/dbt_copilot_helper/templates/addons/env/aurora-postgres.yml
@@ -92,6 +92,27 @@ Resources:
         log_statement: ddl
         log_statement_sample_rate: '1.0'
 
+  {{ service.prefix }}KMSKey:
+    Type: "AWS::KMS::Key"
+    Properties: 
+      Description: "KMS Key for Aurora encryption"
+      KeyPolicy:
+        Version: '2012-10-17'
+        Id: !Sub '${App}-${Env}-cluster-key'
+        Statement:
+        - Sid: Enable IAM User Permissions
+          Effect: Allow
+          Principal:
+            AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+          Action: kms:*
+          Resource: '*'
+
+  {{ service.prefix }}KeyAlias:
+    Type: 'AWS::KMS::Alias'
+    Properties:
+      AliasName: !Sub 'alias/${App}-${Env}-cluster-key'
+      TargetKeyId: !Ref {{ service.prefix }}KMSKey
+
   {{ service.prefix }}DBCluster:
     Metadata:
       'aws:copilot:description': 'The {{ service.prefix }} Aurora Serverless v2 database cluster'
@@ -109,6 +130,7 @@ Resources:
         - postgresql
       DBClusterParameterGroupName: !Ref {{ service.prefix }}DBClusterParameterGroup
       DBSubnetGroupName: !Ref {{ service.prefix }}DBSubnetGroup
+      KmsKeyId: !Ref {{ service.prefix }}KMSKey
       Port: 5432
       VpcSecurityGroupIds:
         - !Ref {{ service.prefix }}DBClusterSecurityGroup

--- a/dbt_copilot_helper/templates/addons/env/aurora-postgres.yml
+++ b/dbt_copilot_helper/templates/addons/env/aurora-postgres.yml
@@ -98,7 +98,7 @@ Resources:
       Description: "KMS Key for Aurora encryption"
       KeyPolicy:
         Version: '2012-10-17'
-        Id: !Sub '${App}-${Env}-cluster-key'
+        Id: !Sub '${App}-${Env}-{{ service.prefix }}-cluster-key'
         Statement:
         - Sid: Enable IAM User Permissions
           Effect: Allow
@@ -110,7 +110,7 @@ Resources:
   {{ service.prefix }}KeyAlias:
     Type: 'AWS::KMS::Alias'
     Properties:
-      AliasName: !Sub 'alias/${App}-${Env}-cluster-key'
+      AliasName: !Sub 'alias/${App}-${Env}-{{ service.prefix }}-cluster-key'
       TargetKeyId: !Ref {{ service.prefix }}KMSKey
 
   {{ service.prefix }}DBCluster:

--- a/dbt_copilot_helper/templates/addons/env/rds-postgres.yml
+++ b/dbt_copilot_helper/templates/addons/env/rds-postgres.yml
@@ -82,6 +82,27 @@ Resources:
         log_statement: ddl
         log_statement_sample_rate: '1.0'
 
+  {{ service.prefix }}KMSKey:
+    Type: "AWS::KMS::Key"
+    Properties: 
+      Description: "KMS Key for RDS encryption"
+      KeyPolicy:
+        Version: '2012-10-17'
+        Id: !Sub '${App}-${Env}-cluster-key'
+        Statement:
+        - Sid: Enable IAM User Permissions
+          Effect: Allow
+          Principal:
+            AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+          Action: kms:*
+          Resource: '*'
+    
+  {{ service.prefix }}KeyAlias:
+    Type: 'AWS::KMS::Alias'
+    Properties:
+      AliasName: !Sub 'alias/${App}-${Env}-cluster-key'
+      TargetKeyId: !Ref {{ service.prefix }}KMSKey
+
   # The cluster itself.
   {{ service.prefix }}DBInstance:
     Metadata:
@@ -104,6 +125,7 @@ Resources:
       AllowMajorVersionUpgrade: false
       BackupRetentionPeriod: 7
       DBName: !Ref {{ service.prefix }}DBName
+      KmsKeyId: !Ref {{ service.prefix }}KMSKey
       MasterUsername:
         !Join [ "",  [ '{% raw %}{{{% endraw %}resolve:secretsmanager:', !Ref {{ service.prefix }}RDSSecret, ":SecretString:username{% raw %}}}{% endraw %}" ]]
       MasterUserPassword:
@@ -111,6 +133,7 @@ Resources:
       DBSubnetGroupName: !Ref '{{ service.prefix }}DBSubnetGroup'
       VPCSecurityGroups:
         - !Ref {{ service.prefix }}SecurityGroup
+      StorageEncrypted: true
 
   {{ service.prefix }}RDSSecret:
     Metadata:

--- a/dbt_copilot_helper/templates/addons/env/rds-postgres.yml
+++ b/dbt_copilot_helper/templates/addons/env/rds-postgres.yml
@@ -88,7 +88,7 @@ Resources:
       Description: "KMS Key for RDS encryption"
       KeyPolicy:
         Version: '2012-10-17'
-        Id: !Sub '${App}-${Env}-cluster-key'
+        Id: !Sub '${App}-${Env}-{{ service.prefix }}-key'
         Statement:
         - Sid: Enable IAM User Permissions
           Effect: Allow
@@ -100,7 +100,7 @@ Resources:
   {{ service.prefix }}KeyAlias:
     Type: 'AWS::KMS::Alias'
     Properties:
-      AliasName: !Sub 'alias/${App}-${Env}-cluster-key'
+      AliasName: !Sub 'alias/${App}-${Env}-{{ service.prefix }}-key'
       TargetKeyId: !Ref {{ service.prefix }}KMSKey
 
   # The cluster itself.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1418,6 +1418,16 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
+    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -2227,6 +2237,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -2234,8 +2245,15 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -2252,6 +2270,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -2259,6 +2278,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -2619,13 +2639,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "1.26.17"
+version = "1.26.18"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 files = [
-    {file = "urllib3-1.26.17-py2.py3-none-any.whl", hash = "sha256:94a757d178c9be92ef5539b8840d48dc9cf1b2709c9d6b588232a055c524458b"},
-    {file = "urllib3-1.26.17.tar.gz", hash = "sha256:24d6a242c28d29af46c3fae832c36db3bbebcc533dd1bb549172cd739c82df21"},
+    {file = "urllib3-1.26.18-py2.py3-none-any.whl", hash = "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"},
+    {file = "urllib3-1.26.18.tar.gz", hash = "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"},
 ]
 
 [package.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.61"
+version = "0.1.62"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/fixtures/make_addons/expected/environments/addons/my-aurora-db.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-aurora-db.yml
@@ -98,7 +98,7 @@ Resources:
       Description: "KMS Key for Aurora encryption"
       KeyPolicy:
         Version: '2012-10-17'
-        Id: !Sub '${App}-${Env}-cluster-key'
+        Id: !Sub '${App}-${Env}-myAuroraDb-cluster-key'
         Statement:
         - Sid: Enable IAM User Permissions
           Effect: Allow
@@ -110,7 +110,7 @@ Resources:
   myAuroraDbKeyAlias:
     Type: 'AWS::KMS::Alias'
     Properties:
-      AliasName: !Sub 'alias/${App}-${Env}-cluster-key'
+      AliasName: !Sub 'alias/${App}-${Env}-myAuroraDb-cluster-key'
       TargetKeyId: !Ref myAuroraDbKMSKey
 
   myAuroraDbDBCluster:

--- a/tests/fixtures/make_addons/expected/environments/addons/my-aurora-db.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-aurora-db.yml
@@ -92,6 +92,27 @@ Resources:
         log_statement: ddl
         log_statement_sample_rate: '1.0'
 
+  myAuroraDbKMSKey:
+    Type: "AWS::KMS::Key"
+    Properties: 
+      Description: "KMS Key for Aurora encryption"
+      KeyPolicy:
+        Version: '2012-10-17'
+        Id: !Sub '${App}-${Env}-cluster-key'
+        Statement:
+        - Sid: Enable IAM User Permissions
+          Effect: Allow
+          Principal:
+            AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+          Action: kms:*
+          Resource: '*'
+
+  myAuroraDbKeyAlias:
+    Type: 'AWS::KMS::Alias'
+    Properties:
+      AliasName: !Sub 'alias/${App}-${Env}-cluster-key'
+      TargetKeyId: !Ref myAuroraDbKMSKey
+
   myAuroraDbDBCluster:
     Metadata:
       'aws:copilot:description': 'The myAuroraDb Aurora Serverless v2 database cluster'
@@ -109,6 +130,7 @@ Resources:
         - postgresql
       DBClusterParameterGroupName: !Ref myAuroraDbDBClusterParameterGroup
       DBSubnetGroupName: !Ref myAuroraDbDBSubnetGroup
+      KmsKeyId: !Ref myAuroraDbKMSKey
       Port: 5432
       VpcSecurityGroupIds:
         - !Ref myAuroraDbDBClusterSecurityGroup

--- a/tests/fixtures/make_addons/expected/environments/addons/my-rds-db.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-rds-db.yml
@@ -82,6 +82,27 @@ Resources:
         log_statement: ddl
         log_statement_sample_rate: '1.0'
 
+  myRdsDbKMSKey:
+    Type: "AWS::KMS::Key"
+    Properties: 
+      Description: "KMS Key for RDS encryption"
+      KeyPolicy:
+        Version: '2012-10-17'
+        Id: !Sub '${App}-${Env}-cluster-key'
+        Statement:
+        - Sid: Enable IAM User Permissions
+          Effect: Allow
+          Principal:
+            AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+          Action: kms:*
+          Resource: '*'
+    
+  myRdsDbKeyAlias:
+    Type: 'AWS::KMS::Alias'
+    Properties:
+      AliasName: !Sub 'alias/${App}-${Env}-cluster-key'
+      TargetKeyId: !Ref myRdsDbKMSKey
+
   # The cluster itself.
   myRdsDbDBInstance:
     Metadata:
@@ -104,6 +125,7 @@ Resources:
       AllowMajorVersionUpgrade: false
       BackupRetentionPeriod: 7
       DBName: !Ref myRdsDbDBName
+      KmsKeyId: !Ref myRdsDbKMSKey
       MasterUsername:
         !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myRdsDbRDSSecret, ":SecretString:username}}" ]]
       MasterUserPassword:
@@ -111,6 +133,7 @@ Resources:
       DBSubnetGroupName: !Ref 'myRdsDbDBSubnetGroup'
       VPCSecurityGroups:
         - !Ref myRdsDbSecurityGroup
+      StorageEncrypted: true
 
   myRdsDbRDSSecret:
     Metadata:

--- a/tests/fixtures/make_addons/expected/environments/addons/my-rds-db.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-rds-db.yml
@@ -88,7 +88,7 @@ Resources:
       Description: "KMS Key for RDS encryption"
       KeyPolicy:
         Version: '2012-10-17'
-        Id: !Sub '${App}-${Env}-cluster-key'
+        Id: !Sub '${App}-${Env}-myRdsDb-key'
         Statement:
         - Sid: Enable IAM User Permissions
           Effect: Allow
@@ -100,7 +100,7 @@ Resources:
   myRdsDbKeyAlias:
     Type: 'AWS::KMS::Alias'
     Properties:
-      AliasName: !Sub 'alias/${App}-${Env}-cluster-key'
+      AliasName: !Sub 'alias/${App}-${Env}-myRdsDb-key'
       TargetKeyId: !Ref myRdsDbKMSKey
 
   # The cluster itself.


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/DBTP-497

[Original pen test report](https://dbis.sharepoint.com/sites/CyberTeam/Shared%20Documents/Forms/AllItems.aspx?id=%2Fsites%2FCyberTeam%2FShared%20Documents%2FDDaT%20SharePoint%20folder%2F21%2D%20Pentests%2F2022%2D2023%2F11%2E%20DBT%20Paas%2FUKP%2D2345%2DRPT%2D01%20Department%20for%20Business%20and%20Trade%20DBT%20PaaS%20IT%20Health%20CHECK%20Report%20v1%2E0%2Epdf&parent=%2Fsites%2FCyberTeam%2FShared%20Documents%2FDDaT%20SharePoint%20folder%2F21%2D%20Pentests%2F2022%2D2023%2F11%2E%20DBT%20Paas&p=true&ga=1)

Makes RDS and aurora templates use a customer-managed KMS key, rather than the AWS default used currently.