### PR TITLE
DBTP-540 Retain 7 days of RDS backups

### DIFF
--- a/dbt_copilot_helper/templates/addons/env/aurora-postgres.yml
+++ b/dbt_copilot_helper/templates/addons/env/aurora-postgres.yml
@@ -95,7 +95,7 @@ Resources:
 
   {{ service.prefix }}KMSKey:
     Type: "AWS::KMS::Key"
-    Properties: 
+    Properties:
       Description: "KMS Key for Aurora encryption"
       KeyPolicy:
         Version: '2012-10-17'
@@ -120,6 +120,7 @@ Resources:
     Type: 'AWS::RDS::DBCluster'
     Properties:
       AutoMinorVersionUpgrade: true
+      BackupRetentionPeriod: 8
       MasterUsername:
         !Join [ "",  [ '{% raw %}{{{% endraw %}resolve:secretsmanager:', !Ref {{ service.prefix }}AuroraSecret, ":SecretString:username{% raw %}}}{% endraw %}" ]]
       MasterUserPassword:

--- a/dbt_copilot_helper/templates/addons/env/rds-postgres.yml
+++ b/dbt_copilot_helper/templates/addons/env/rds-postgres.yml
@@ -145,7 +145,7 @@ Resources:
 
   {{ service.prefix }}KMSKey:
     Type: "AWS::KMS::Key"
-    Properties: 
+    Properties:
       Description: "KMS Key for RDS encryption"
       KeyPolicy:
         Version: '2012-10-17'
@@ -157,7 +157,7 @@ Resources:
             AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
           Action: kms:*
           Resource: '*'
-    
+
   {{ service.prefix }}KeyAlias:
     Type: 'AWS::KMS::Alias'
     Properties:
@@ -170,7 +170,9 @@ Resources:
       'aws:copilot:description': 'DB cluster'
     Type: AWS::RDS::DBInstance
     Properties:
+      AllowMajorVersionUpgrade: false
       AutoMinorVersionUpgrade: true
+      BackupRetentionPeriod: 8
       EnablePerformanceInsights: true
       EnableCloudwatchLogsExports:
         - postgresql
@@ -183,8 +185,6 @@ Resources:
       StorageType: !FindInMap [{{ service.prefix }}EnvScalingConfigurationMap, !Ref Env, StorageType]
       MultiAZ: !FindInMap [{{ service.prefix }}EnvScalingConfigurationMap, !Ref Env, MultiAZ]
       DBParameterGroupName: !Ref {{ service.prefix }}RDSDBParameterGroup
-      AllowMajorVersionUpgrade: false
-      BackupRetentionPeriod: 7
       DBName: !Ref {{ service.prefix }}DBName
       KmsKeyId: !Ref {{ service.prefix }}KMSKey
       MasterUsername:

--- a/tests/fixtures/make_addons/expected/environments/addons/my-aurora-db.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-aurora-db.yml
@@ -95,7 +95,7 @@ Resources:
 
   myAuroraDbKMSKey:
     Type: "AWS::KMS::Key"
-    Properties: 
+    Properties:
       Description: "KMS Key for Aurora encryption"
       KeyPolicy:
         Version: '2012-10-17'
@@ -120,6 +120,7 @@ Resources:
     Type: 'AWS::RDS::DBCluster'
     Properties:
       AutoMinorVersionUpgrade: true
+      BackupRetentionPeriod: 8
       MasterUsername:
         !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myAuroraDbAuroraSecret, ":SecretString:username}}" ]]
       MasterUserPassword:

--- a/tests/fixtures/make_addons/expected/environments/addons/my-rds-db.yml
+++ b/tests/fixtures/make_addons/expected/environments/addons/my-rds-db.yml
@@ -143,7 +143,7 @@ Resources:
 
   myRdsDbKMSKey:
     Type: "AWS::KMS::Key"
-    Properties: 
+    Properties:
       Description: "KMS Key for RDS encryption"
       KeyPolicy:
         Version: '2012-10-17'
@@ -155,7 +155,7 @@ Resources:
             AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
           Action: kms:*
           Resource: '*'
-    
+
   myRdsDbKeyAlias:
     Type: 'AWS::KMS::Alias'
     Properties:
@@ -168,7 +168,9 @@ Resources:
       'aws:copilot:description': 'DB cluster'
     Type: AWS::RDS::DBInstance
     Properties:
+      AllowMajorVersionUpgrade: false
       AutoMinorVersionUpgrade: true
+      BackupRetentionPeriod: 8
       EnablePerformanceInsights: true
       EnableCloudwatchLogsExports:
         - postgresql
@@ -181,8 +183,6 @@ Resources:
       StorageType: !FindInMap [myRdsDbEnvScalingConfigurationMap, !Ref Env, StorageType]
       MultiAZ: !FindInMap [myRdsDbEnvScalingConfigurationMap, !Ref Env, MultiAZ]
       DBParameterGroupName: !Ref myRdsDbRDSDBParameterGroup
-      AllowMajorVersionUpgrade: false
-      BackupRetentionPeriod: 7
       DBName: !Ref myRdsDbDBName
       KmsKeyId: !Ref myRdsDbKMSKey
       MasterUsername:


### PR DESCRIPTION
`BackupRetentionPeriod` was already set to `7` for RDS Postgres.

As far as I can tell from looking at my demodjango environment's backups, where RDS Postgres already had `BackupRetentionPeriod` set `7`, that only actually results in it keeping the last 6 backups. This felt wrong to me so I have set both to `8`.