### PR TITLE
DBTP-551 Stop checking image repository name contains service name

### DIFF
--- a/dbt_copilot_helper/commands/svc.py
+++ b/dbt_copilot_helper/commands/svc.py
@@ -91,12 +91,4 @@ def validate_service_manifest_and_return_repository(name):
         )
         exit(1)
 
-    repository_name = get_repository_name_from_manifest(service_manifest)
-    if service_name_in_manifest not in repository_name:
-        click.secho(
-            f"The image location does not contain the service name ({name}) in the service manifest.",
-            fg="red",
-        )
-        exit(1)
-
-    return repository_name
+    return get_repository_name_from_manifest(service_manifest)

--- a/tests/copilot_helper/test_command_svc.py
+++ b/tests/copilot_helper/test_command_svc.py
@@ -206,45 +206,6 @@ def test_svc_deploy_with_mismatched_name_in_manifest_file_fails_with_message(
     assert f"Service manifest for {other_name} has name attribute {name}" in result.stdout
 
 
-@patch("boto3.client")
-@patch("subprocess.call")
-def test_svc_deploy_with_service_name_not_in_image_location_fails_with_message(
-    subprocess_call, mock_boto_client, tmp_path
-):
-    """If the manifest image location does not contain the service name, fail
-    with a message."""
-    branch_name, commit_hash, env, name = set_up_test_variables()
-    mock_describe_images_return_tags(branch_name, commit_hash, mock_boto_client)
-
-    os.chdir(tmp_path)
-    manifest_dir = Path("copilot") / name
-    os.makedirs(manifest_dir)
-    shutil.copy(
-        UTILS_FIXTURES_DIR
-        / "test_service_manifest_with_mismatched_service_name_and_image_location.yml",
-        manifest_dir / "manifest.yml",
-    )
-
-    result = CliRunner().invoke(
-        deploy,
-        [
-            "--env",
-            env,
-            "--name",
-            name,
-            "--image-tag",
-            f"commit-{commit_hash}",
-        ],
-    )
-
-    mock_boto_client.describe_images.assert_not_called()
-    assert result.exit_code == 1
-    assert (
-        f"The image location does not contain the service name (test-service) in the service manifest."
-        in result.stdout
-    )
-
-
 def mock_describe_images_return_tags(branch_name, commit_hash, mock_boto_client):
     mock_boto_client.return_value = mock_boto_client
     image_tags = [


### PR DESCRIPTION
Addresses: https://uktrade.atlassian.net/browse/DBTP-551

When @antroy-madetech and wrote this code we thought all image repository names would include the `/web` etc. part. Turns out this is not the case and I think we can simply remove that requirement.