### PR TITLE
DBTP-544 - Fix custom resource deletion hanging

### DIFF
--- a/dbt_copilot_helper/templates/addons/env/addons.parameters.yml
+++ b/dbt_copilot_helper/templates/addons/env/addons.parameters.yml
@@ -7,6 +7,12 @@
 
 Parameters:
   EnvironmentSecurityGroup: !Ref EnvironmentSecurityGroup
+  DefaultPublicRoute: !Ref DefaultPublicRoute
+  InternetGateway: !Ref InternetGateway
+  InternetGatewayAttachment: !Ref InternetGatewayAttachment
   PrivateSubnets: !Join [ ',', [ !Ref PrivateSubnet1, !Ref PrivateSubnet2, ] ]
+  PublicRouteTable: !Ref PublicRouteTable
+  PublicSubnet1RouteTableAssociation: !Ref PublicSubnet1RouteTableAssociation
+  PublicSubnet2RouteTableAssociation: !Ref PublicSubnet2RouteTableAssociation
   PublicSubnets: !Join [ ',', [ !Ref PublicSubnet1, !Ref PublicSubnet2, ] ]
   VpcId: !Ref VPC

--- a/dbt_copilot_helper/templates/addons/env/aurora-postgres.yml
+++ b/dbt_copilot_helper/templates/addons/env/aurora-postgres.yml
@@ -12,7 +12,19 @@ Parameters:
   # Parameters from the parent stack brought in via addons.parameters.yml...
   EnvironmentSecurityGroup:
     Type: String
+  DefaultPublicRoute:
+    Type: String
+  InternetGateway:
+    Type: String
+  InternetGatewayAttachment:
+    Type: String
   PrivateSubnets:
+    Type: String
+  PublicRouteTable:
+    Type: String
+  PublicSubnet1RouteTableAssociation:
+    Type: String
+  PublicSubnet2RouteTableAssociation:
     Type: String
   VpcId:
     Type: String
@@ -407,6 +419,12 @@ Resources:
       MasterUserSecret: !Ref {{ service.prefix }}AuroraSecret
       SecretDescription: !Sub Aurora application user secret for ${AWS::StackName}
       SecretName: !Sub '/copilot/${App}/${Env}/secrets/{{ service.name|upper|replace("-", "_") }}_APPLICATION_USER'
+      DefaultPublicRoute: !Ref DefaultPublicRoute
+      InternetGateway: !Ref InternetGateway
+      InternetGatewayAttachment: !Ref InternetGatewayAttachment
+      PublicRouteTable: !Ref PublicRouteTable
+      PublicSubnet1RouteTableAssociation: !Ref PublicSubnet1RouteTableAssociation
+      PublicSubnet2RouteTableAssociation: !Ref PublicSubnet2RouteTableAssociation
     # Resource based metadata block to ignore reference to resources in other addon templates. Do not remove.
     Metadata:
       cfn-lint:
@@ -417,6 +435,22 @@ Resources:
     DependsOn:
       - VpcEndpoint
       - {{ service.prefix }}DBWriterInstance
+      - AdditionalNatGateway1
+      - AdditionalNatGateway2
+      - AdditionalPrivateRoute1
+      - AdditionalPrivateRouteTable1
+      - AdditionalPrivateRouteTable1Association
+      - AdditionalPrivateRoute2
+      - AdditionalPrivateRouteTable2
+      - AdditionalPrivateRouteTable2Association
+      - {{ service.prefix }}SecretAuroraClusterAttachment
+      - {{ service.prefix }}EnvironmentIngress
+      - {{ service.prefix }}SecretsManagerIngress
+      - {{ service.prefix }}LambdaIngress
+      - {{ service.prefix }}SecretsManagerEgress
+      - {{ service.prefix }}LambdaEgress
+      - {{ service.prefix }}HTTPSEgress
+      - {{ service.prefix }}KeyAlias
 
   {{ service.prefix }}LambdaFunctionExecutionRole:
     Type: AWS::IAM::Role

--- a/dbt_copilot_helper/templates/addons/env/rds-postgres.yml
+++ b/dbt_copilot_helper/templates/addons/env/rds-postgres.yml
@@ -12,7 +12,19 @@ Parameters:
   # Parameters from the parent stack brought in via addons.parameters.yml...
   EnvironmentSecurityGroup:
     Type: String
+  DefaultPublicRoute:
+    Type: String
+  InternetGateway:
+    Type: String
+  InternetGatewayAttachment:
+    Type: String
   PrivateSubnets:
+    Type: String
+  PublicRouteTable:
+    Type: String
+  PublicSubnet1RouteTableAssociation:
+    Type: String
+  PublicSubnet2RouteTableAssociation:
     Type: String
   VpcId:
     Type: String
@@ -389,6 +401,12 @@ Resources:
       MasterUserSecret: !Ref {{ service.prefix }}RDSSecret
       SecretDescription: !Sub RDS application user secret for ${AWS::StackName}
       SecretName: !Sub '/copilot/${App}/${Env}/secrets/{{ service.name|upper|replace("-", "_") }}_APPLICATION_USER'
+      DefaultPublicRoute: !Ref DefaultPublicRoute
+      InternetGateway: !Ref InternetGateway
+      InternetGatewayAttachment: !Ref InternetGatewayAttachment
+      PublicRouteTable: !Ref PublicRouteTable
+      PublicSubnet1RouteTableAssociation: !Ref PublicSubnet1RouteTableAssociation
+      PublicSubnet2RouteTableAssociation: !Ref PublicSubnet2RouteTableAssociation
     # Resource based metadata block to ignore reference to resources in other addon templates. Do not remove.
     Metadata:
       cfn-lint:
@@ -399,6 +417,22 @@ Resources:
     DependsOn:
       - VpcEndpoint
       - {{ service.prefix }}DBInstance
+      - AdditionalNatGateway1
+      - AdditionalNatGateway2
+      - AdditionalPrivateRoute1
+      - AdditionalPrivateRouteTable1
+      - AdditionalPrivateRouteTable1Association
+      - AdditionalPrivateRoute2
+      - AdditionalPrivateRouteTable2
+      - AdditionalPrivateRouteTable2Association
+      - {{ service.prefix }}SecretRDSAttachment
+      - {{ service.prefix }}DBIngress
+      - {{ service.prefix }}SecretsManagerIngress
+      - {{ service.prefix }}LambdaIngress
+      - {{ service.prefix }}SecretsManagerEgress
+      - {{ service.prefix }}LambdaEgress
+      - {{ service.prefix }}HTTPSEgress
+      - {{ service.prefix }}KeyAlias
 
   {{ service.prefix }}LambdaFunctionExecutionRole:
     Type: AWS::IAM::Role

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.72"
+version = "0.1.73"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/addons.parameters.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/addons.parameters.yml
@@ -7,6 +7,12 @@
 
 Parameters:
   EnvironmentSecurityGroup: !Ref EnvironmentSecurityGroup
+  DefaultPublicRoute: !Ref DefaultPublicRoute
+  InternetGateway: !Ref InternetGateway
+  InternetGatewayAttachment: !Ref InternetGatewayAttachment
   PrivateSubnets: !Join [ ',', [ !Ref PrivateSubnet1, !Ref PrivateSubnet2, ] ]
+  PublicRouteTable: !Ref PublicRouteTable
+  PublicSubnet1RouteTableAssociation: !Ref PublicSubnet1RouteTableAssociation
+  PublicSubnet2RouteTableAssociation: !Ref PublicSubnet2RouteTableAssociation
   PublicSubnets: !Join [ ',', [ !Ref PublicSubnet1, !Ref PublicSubnet2, ] ]
   VpcId: !Ref VPC

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-aurora-db.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-aurora-db.yml
@@ -12,7 +12,19 @@ Parameters:
   # Parameters from the parent stack brought in via addons.parameters.yml...
   EnvironmentSecurityGroup:
     Type: String
+  DefaultPublicRoute:
+    Type: String
+  InternetGateway:
+    Type: String
+  InternetGatewayAttachment:
+    Type: String
   PrivateSubnets:
+    Type: String
+  PublicRouteTable:
+    Type: String
+  PublicSubnet1RouteTableAssociation:
+    Type: String
+  PublicSubnet2RouteTableAssociation:
     Type: String
   VpcId:
     Type: String
@@ -407,6 +419,12 @@ Resources:
       MasterUserSecret: !Ref myAuroraDbAuroraSecret
       SecretDescription: !Sub Aurora application user secret for ${AWS::StackName}
       SecretName: !Sub '/copilot/${App}/${Env}/secrets/MY_AURORA_DB_APPLICATION_USER'
+      DefaultPublicRoute: !Ref DefaultPublicRoute
+      InternetGateway: !Ref InternetGateway
+      InternetGatewayAttachment: !Ref InternetGatewayAttachment
+      PublicRouteTable: !Ref PublicRouteTable
+      PublicSubnet1RouteTableAssociation: !Ref PublicSubnet1RouteTableAssociation
+      PublicSubnet2RouteTableAssociation: !Ref PublicSubnet2RouteTableAssociation
     # Resource based metadata block to ignore reference to resources in other addon templates. Do not remove.
     Metadata:
       cfn-lint:
@@ -417,6 +435,22 @@ Resources:
     DependsOn:
       - VpcEndpoint
       - myAuroraDbDBWriterInstance
+      - AdditionalNatGateway1
+      - AdditionalNatGateway2
+      - AdditionalPrivateRoute1
+      - AdditionalPrivateRouteTable1
+      - AdditionalPrivateRouteTable1Association
+      - AdditionalPrivateRoute2
+      - AdditionalPrivateRouteTable2
+      - AdditionalPrivateRouteTable2Association
+      - myAuroraDbSecretAuroraClusterAttachment
+      - myAuroraDbEnvironmentIngress
+      - myAuroraDbSecretsManagerIngress
+      - myAuroraDbLambdaIngress
+      - myAuroraDbSecretsManagerEgress
+      - myAuroraDbLambdaEgress
+      - myAuroraDbHTTPSEgress
+      - myAuroraDbKeyAlias
 
   myAuroraDbLambdaFunctionExecutionRole:
     Type: AWS::IAM::Role

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-rds-db.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-rds-db.yml
@@ -12,7 +12,19 @@ Parameters:
   # Parameters from the parent stack brought in via addons.parameters.yml...
   EnvironmentSecurityGroup:
     Type: String
+  DefaultPublicRoute:
+    Type: String
+  InternetGateway:
+    Type: String
+  InternetGatewayAttachment:
+    Type: String
   PrivateSubnets:
+    Type: String
+  PublicRouteTable:
+    Type: String
+  PublicSubnet1RouteTableAssociation:
+    Type: String
+  PublicSubnet2RouteTableAssociation:
     Type: String
   VpcId:
     Type: String
@@ -387,6 +399,12 @@ Resources:
       MasterUserSecret: !Ref myRdsDbRDSSecret
       SecretDescription: !Sub RDS application user secret for ${AWS::StackName}
       SecretName: !Sub '/copilot/${App}/${Env}/secrets/MY_RDS_DB_APPLICATION_USER'
+      DefaultPublicRoute: !Ref DefaultPublicRoute
+      InternetGateway: !Ref InternetGateway
+      InternetGatewayAttachment: !Ref InternetGatewayAttachment
+      PublicRouteTable: !Ref PublicRouteTable
+      PublicSubnet1RouteTableAssociation: !Ref PublicSubnet1RouteTableAssociation
+      PublicSubnet2RouteTableAssociation: !Ref PublicSubnet2RouteTableAssociation
     # Resource based metadata block to ignore reference to resources in other addon templates. Do not remove.
     Metadata:
       cfn-lint:
@@ -397,6 +415,22 @@ Resources:
     DependsOn:
       - VpcEndpoint
       - myRdsDbDBInstance
+      - AdditionalNatGateway1
+      - AdditionalNatGateway2
+      - AdditionalPrivateRoute1
+      - AdditionalPrivateRouteTable1
+      - AdditionalPrivateRouteTable1Association
+      - AdditionalPrivateRoute2
+      - AdditionalPrivateRouteTable2
+      - AdditionalPrivateRouteTable2Association
+      - myRdsDbSecretRDSAttachment
+      - myRdsDbDBIngress
+      - myRdsDbSecretsManagerIngress
+      - myRdsDbLambdaIngress
+      - myRdsDbSecretsManagerEgress
+      - myRdsDbLambdaEgress
+      - myRdsDbHTTPSEgress
+      - myRdsDbKeyAlias
 
   myRdsDbLambdaFunctionExecutionRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
## Context

- Add dependencies to PostgreSQL user custom resource
  - The main/parent CloudFormation stack has the internet gateway, public routes, and public subnets, so when a `copilot env delete` is executed, the resources in the root and nested stacks are delete in parallel. This means the Lambda Function loses access to the database and also the internet without these additional dependencies.
  - This change means the custom resource is deleted first along with the Parameter Store secret for the PostgreSQL application user when running `copilot env delete --name <environment>`.
- Update package version from `0.1.72` -> `0.1.73`

## Additional information

This is a far from ideal solution. The reason to take this approach rather than the `dependsOn` attribute within the Custom Resource is because this attribute only allows resources from the **same** stack. More detail in this [Jira comment](https://uktrade.atlassian.net/browse/DBTP-544?focusedCommentId=127364) as well.

In the future, we should consider provisioning database application users for each service at the service-level rather than the environment-level, as mentioned by @acodeninja in this [Jira comment](https://uktrade.atlassian.net/browse/DBTP-476?focusedCommentId=127099).