### PR TITLE
DBTP-550 - Fix S3 public access policies

### DIFF
--- a/dbt_copilot_helper/templates/addons/env/s3.yml
+++ b/dbt_copilot_helper/templates/addons/env/s3.yml
@@ -57,6 +57,8 @@ Resources:
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       Tags:
         - Key: Copilot-application
           Value: !Ref App

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.73"
+version = "0.1.74"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-s3-bucket-with-an-object.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-s3-bucket-with-an-object.yml
@@ -57,6 +57,8 @@ Resources:
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       Tags:
         - Key: Copilot-application
           Value: !Ref App

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-s3-bucket.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-s3-bucket.yml
@@ -57,6 +57,8 @@ Resources:
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
       Tags:
         - Key: Copilot-application
           Value: !Ref App


### PR DESCRIPTION
`<application>-s3-bucket-<environment>-logs` is created with public access enabled. Public access should be blocked.