### PR TITLE
DBTP-545 Remove old school S3 logging to an S3 bucket

### DIFF
--- a/dbt_copilot_helper/templates/addons/env/s3.yml
+++ b/dbt_copilot_helper/templates/addons/env/s3.yml
@@ -15,7 +15,6 @@ Mappings:
 {% for env_name, config in service.environments.items() %}
     {{ env_name }}:
       BucketName: '{{ config.bucket_name }}'
-      LoggingBucketName: '{{ config.bucket_name }}-logs'
 {% endfor %}
 
 Resources:
@@ -40,52 +39,6 @@ Resources:
       AliasName: !Sub 'alias/${App}-${Env}-{{ service.prefix }}-key'
       TargetKeyId: !Ref {{ service.prefix }}KMSKey
 
-  {{ service.prefix }}LoggingBucket:
-    Metadata:
-      'aws:copilot:description': 'An Amazon S3 bucket to store logs from {{ service.prefix }}Bucket'
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName: !FindInMap [{{ service.prefix }}BucketNameMap, !Ref Env, LoggingBucketName]
-      AccessControl: Private
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-        - ServerSideEncryptionByDefault:
-            SSEAlgorithm: aws:kms
-            KMSMasterKeyID: !Ref {{ service.prefix }}KMSKey
-      VersioningConfiguration:
-        Status: Enabled
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-      Tags:
-        - Key: Copilot-application
-          Value: !Ref App
-        - Key: Copilot-environment
-          Value: !Ref Env
-
-  {{ service.prefix }}LoggingBucketPolicy:
-    Metadata:
-      'aws:copilot:description': 'A bucket policy to deny unencrypted access to the bucket and its contents'
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: S3ServerAccessLogsPolicy
-            Effect: Allow
-            Principal:
-              Service: logging.s3.amazonaws.com
-            Action: 's3:PutObject'
-            Resource:
-              - !Sub ${ {{ service.prefix }}LoggingBucket.Arn}/*
-              - !Sub ${ {{ service.prefix }}LoggingBucket.Arn}
-            Condition:
-              ArnLike:
-                'aws:SourceArn': !Sub ${ {{ service.prefix }}Bucket.Arn}
-              StringEquals:
-                'aws:SourceAccount': !Sub ${AWS::AccountId}
-      Bucket: !Ref {{ service.prefix }}LoggingBucket
-
   {{ service.prefix }}Bucket:
     Metadata:
       'aws:copilot:description': 'An Amazon S3 bucket to store and retrieve objects for {{ service.prefix }}'
@@ -100,8 +53,6 @@ Resources:
             KMSMasterKeyID: !Ref {{ service.prefix }}KMSKey
       VersioningConfiguration:
         Status: Enabled
-      LoggingConfiguration:
-        DestinationBucketName: !FindInMap [{{ service.prefix }}BucketNameMap, !Ref Env, LoggingBucketName]
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.73"
+version = "0.1.74"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-s3-bucket-with-an-object.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-s3-bucket-with-an-object.yml
@@ -15,7 +15,6 @@ Mappings:
 
     development:
       BucketName: 'my-bucket-dev'
-      LoggingBucketName: 'my-bucket-dev-logs'
 
 
 Resources:
@@ -40,52 +39,6 @@ Resources:
       AliasName: !Sub 'alias/${App}-${Env}-myS3BucketWithAnObject-key'
       TargetKeyId: !Ref myS3BucketWithAnObjectKMSKey
 
-  myS3BucketWithAnObjectLoggingBucket:
-    Metadata:
-      'aws:copilot:description': 'An Amazon S3 bucket to store logs from myS3BucketWithAnObjectBucket'
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName: !FindInMap [myS3BucketWithAnObjectBucketNameMap, !Ref Env, LoggingBucketName]
-      AccessControl: Private
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-        - ServerSideEncryptionByDefault:
-            SSEAlgorithm: aws:kms
-            KMSMasterKeyID: !Ref myS3BucketWithAnObjectKMSKey
-      VersioningConfiguration:
-        Status: Enabled
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-      Tags:
-        - Key: Copilot-application
-          Value: !Ref App
-        - Key: Copilot-environment
-          Value: !Ref Env
-
-  myS3BucketWithAnObjectLoggingBucketPolicy:
-    Metadata:
-      'aws:copilot:description': 'A bucket policy to deny unencrypted access to the bucket and its contents'
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: S3ServerAccessLogsPolicy
-            Effect: Allow
-            Principal:
-              Service: logging.s3.amazonaws.com
-            Action: 's3:PutObject'
-            Resource:
-              - !Sub ${ myS3BucketWithAnObjectLoggingBucket.Arn}/*
-              - !Sub ${ myS3BucketWithAnObjectLoggingBucket.Arn}
-            Condition:
-              ArnLike:
-                'aws:SourceArn': !Sub ${ myS3BucketWithAnObjectBucket.Arn}
-              StringEquals:
-                'aws:SourceAccount': !Sub ${AWS::AccountId}
-      Bucket: !Ref myS3BucketWithAnObjectLoggingBucket
-
   myS3BucketWithAnObjectBucket:
     Metadata:
       'aws:copilot:description': 'An Amazon S3 bucket to store and retrieve objects for myS3BucketWithAnObject'
@@ -100,8 +53,6 @@ Resources:
             KMSMasterKeyID: !Ref myS3BucketWithAnObjectKMSKey
       VersioningConfiguration:
         Status: Enabled
-      LoggingConfiguration:
-        DestinationBucketName: !FindInMap [myS3BucketWithAnObjectBucketNameMap, !Ref Env, LoggingBucketName]
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-s3-bucket.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-s3-bucket.yml
@@ -15,7 +15,6 @@ Mappings:
 
     development:
       BucketName: 'my-bucket-dev'
-      LoggingBucketName: 'my-bucket-dev-logs'
 
 
 Resources:
@@ -40,52 +39,6 @@ Resources:
       AliasName: !Sub 'alias/${App}-${Env}-myS3Bucket-key'
       TargetKeyId: !Ref myS3BucketKMSKey
 
-  myS3BucketLoggingBucket:
-    Metadata:
-      'aws:copilot:description': 'An Amazon S3 bucket to store logs from myS3BucketBucket'
-    Type: AWS::S3::Bucket
-    Properties:
-      BucketName: !FindInMap [myS3BucketBucketNameMap, !Ref Env, LoggingBucketName]
-      AccessControl: Private
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-        - ServerSideEncryptionByDefault:
-            SSEAlgorithm: aws:kms
-            KMSMasterKeyID: !Ref myS3BucketKMSKey
-      VersioningConfiguration:
-        Status: Enabled
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-      Tags:
-        - Key: Copilot-application
-          Value: !Ref App
-        - Key: Copilot-environment
-          Value: !Ref Env
-
-  myS3BucketLoggingBucketPolicy:
-    Metadata:
-      'aws:copilot:description': 'A bucket policy to deny unencrypted access to the bucket and its contents'
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      PolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-          - Sid: S3ServerAccessLogsPolicy
-            Effect: Allow
-            Principal:
-              Service: logging.s3.amazonaws.com
-            Action: 's3:PutObject'
-            Resource:
-              - !Sub ${ myS3BucketLoggingBucket.Arn}/*
-              - !Sub ${ myS3BucketLoggingBucket.Arn}
-            Condition:
-              ArnLike:
-                'aws:SourceArn': !Sub ${ myS3BucketBucket.Arn}
-              StringEquals:
-                'aws:SourceAccount': !Sub ${AWS::AccountId}
-      Bucket: !Ref myS3BucketLoggingBucket
-
   myS3BucketBucket:
     Metadata:
       'aws:copilot:description': 'An Amazon S3 bucket to store and retrieve objects for myS3Bucket'
@@ -100,8 +53,6 @@ Resources:
             KMSMasterKeyID: !Ref myS3BucketKMSKey
       VersioningConfiguration:
         Status: Enabled
-      LoggingConfiguration:
-        DestinationBucketName: !FindInMap [myS3BucketBucketNameMap, !Ref Env, LoggingBucketName]
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-545

We have CloudTrail event logging enabled for the buckets so the old school logging to an S3 bucket is redundant.

Tested on my `demodjango` environment.