### PR TITLE
DBTP-432 `copilot-helper` commands should not take credentials as arguments

### DIFF
--- a/dbt_copilot_helper/COMMANDS.md
+++ b/dbt_copilot_helper/COMMANDS.md
@@ -281,13 +281,11 @@ copilot-helper codebuild <command>
 ## Usage
 
 ```
-copilot-helper codebuild link-github --pat <pat> --project-profile <project_profile> 
+copilot-helper codebuild link-github --project-profile <project_profile> 
 ```
 
 ## Options
 
-- `--pat <text>`
-  - PAT Token
 - `--project-profile <text>`
   - AWS account profile name
 - `--help <boolean>` _Defaults to False._
@@ -418,7 +416,7 @@ copilot-helper codebuild delete-project --name <name> --project-profile <project
 
 ```
 copilot-helper codebuild slackcreds --workspace <workspace> --channel <channel> 
-                                    --token <token> --project-profile <project_profile> 
+                                    --project-profile <project_profile> 
 ```
 
 ## Options
@@ -427,8 +425,6 @@ copilot-helper codebuild slackcreds --workspace <workspace> --channel <channel>
   - Slack Workspace id
 - `--channel <text>`
   - Slack channel id
-- `--token <text>`
-  - Slack api token
 - `--project-profile <text>`
   - AWS account profile name
 - `--help <boolean>` _Defaults to False._

--- a/dbt_copilot_helper/commands/codebuild.py
+++ b/dbt_copilot_helper/commands/codebuild.py
@@ -234,10 +234,10 @@ def codebuild():
 
 
 @codebuild.command()
-@click.option("--pat", help="PAT Token", required=True)
 @click.option("--project-profile", help="AWS account profile name", required=True)
-def link_github(pat: str, project_profile: str) -> None:
+def link_github(project_profile: str) -> None:
     """Links CodeDeploy to Github via users PAT."""
+    pat = click.prompt("Enter your Github personal access token (PAT):", hide_input=True)
     project_session = check_aws_conn(project_profile)
     client = project_session.client("codebuild", region_name=AWS_REGION)
     import_pat(pat, client)
@@ -398,10 +398,11 @@ def delete_project(name, project_profile):
 @codebuild.command()
 @click.option("--workspace", help="Slack Workspace id", required=True)
 @click.option("--channel", help="Slack channel id", required=True)
-@click.option("--token", help="Slack api token", required=True)
 @click.option("--project-profile", help="AWS account profile name", required=True)
-def slackcreds(workspace, channel, token, project_profile):
+def slackcreds(workspace, channel, project_profile):
     """Add Slack credentials into AWS Parameter Store."""
+    token = click.prompt("Enter your Slack API token", hide_input=True)
+
     project_session = check_aws_conn(project_profile)
 
     SLACK = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.77"
+version = "0.1.78"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/test_command_codebuild.py
+++ b/tests/copilot_helper/test_command_codebuild.py
@@ -117,8 +117,10 @@ def test_check_git_url_invalid(url, capfd):
 def test_link_github(import_pat, alias_session):
     """Test that link_github calls import_pat."""
     runner = CliRunner()
-    runner.invoke(link_github, ["--pat", "123", "--project-profile", "foo"])
+    result = runner.invoke(link_github, ["--project-profile", "foo"], input="pat-token-value")
 
+    assert "Enter your Github personal access token (PAT):" in result.output
+    assert "pat-token-value" not in result.output
     import_pat.assert_called_once()
 
 
@@ -212,14 +214,14 @@ def test_slackcreds(alias_session):
             "workspace",
             "--channel",
             "channel",
-            "--token",
-            "token",
             "--project-profile",
             "foo",
         ],
-        input="y",
+        input="token-value-123\ny",
     )
 
+    assert "Enter your Slack API token:" in result.output
+    assert "token-value-123" not in result.output
     assert "Paramater Store updated" in result.output
 
     SLACK = {
@@ -236,7 +238,7 @@ def test_slackcreds(alias_session):
         "token": {
             "name": "/codebuild/slack_api_token",
             "description": "Slack API Token",
-            "value": "token",
+            "value": "token-value-123",
         },
     }
     for item, value in SLACK.items():


### PR DESCRIPTION
https://uktrade.atlassian.net/browse/DBTP-432

Prevent users from entering secret credentials as command line options.

Documentation PR to follow.