### PR TITLE
DBTP-571 - Fix conduit command error with custom addon name

### DIFF
--- a/dbt_copilot_helper/commands/conduit.py
+++ b/dbt_copilot_helper/commands/conduit.py
@@ -153,8 +153,8 @@ def connect_to_addon_client_task(app: str, env: str, cluster_arn: str, addon_nam
         raise CreateTaskTimeoutConduitError
 
 
-def add_stack_delete_policy_to_task_role(app: str, env: str, addon_type: str):
-    conduit_stack_name = f"task-conduit-{app}-{env}-{app}-{addon_type}"
+def add_stack_delete_policy_to_task_role(app: str, env: str, addon_name: str):
+    conduit_stack_name = f"task-conduit-{app}-{env}-{normalise_string(addon_name)}"
     conduit_stack_resources = boto3.client("cloudformation").list_stack_resources(
         StackName=conduit_stack_name
     )["StackResourceSummaries"]
@@ -189,7 +189,7 @@ def start_conduit(app: str, env: str, addon_type: str, addon_name: str = None):
 
     if not addon_client_is_running(app, env, cluster_arn, addon_name):
         create_addon_client_task(app, env, addon_type, addon_name)
-        add_stack_delete_policy_to_task_role(app, env, addon_type)
+        add_stack_delete_policy_to_task_role(app, env, addon_name)
 
     connect_to_addon_client_task(app, env, cluster_arn, addon_name)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.85"
+version = "0.1.86"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/conftest.py
+++ b/tests/copilot_helper/conftest.py
@@ -200,13 +200,13 @@ def mock_tool_versions():
 
 @pytest.fixture(scope="function")
 def mock_stack():
-    def _create_stack(addon_type):
+    def _create_stack(addon_name):
         with mock_cloudformation():
             with open(FIXTURES_DIR / "test_cloudformation_template_iam_role.json") as f:
                 template_json = json.load(f)
             cf = boto3.client("cloudformation")
             cf.create_stack(
-                StackName=f"task-conduit-test-application-development-test-application-{addon_type}",
+                StackName=f"task-conduit-test-application-development-{addon_name}",
                 TemplateBody=json.dumps(template_json),
             )
 

--- a/tests/copilot_helper/test_command_conduit.py
+++ b/tests/copilot_helper/test_command_conduit.py
@@ -235,15 +235,15 @@ def test_addon_client_is_running_when_no_client_agent_running(
 @mock_iam
 @mock_cloudformation
 @pytest.mark.parametrize(
-    "addon_type",
-    ["postgres", "redis", "opensearch"],
+    "addon_name",
+    ["postgres", "redis", "opensearch", "rds-postgres"],
 )
-def test_add_stack_delete_policy_to_task_role(mock_stack, addon_type):
-    """Test that, given app, env and addon type
+def test_add_stack_delete_policy_to_task_role(mock_stack, addon_name):
+    """Test that, given app, env and addon name
     add_stack_delete_policy_to_task_role adds a policy to the IAM role in a
     CloudFormation stack."""
-    stack_name = f"task-conduit-test-application-development-test-application-{addon_type}"
-    mock_stack(addon_type)
+    stack_name = f"task-conduit-test-application-development-{addon_name}"
+    mock_stack(addon_name)
     mock_policy = {
         "Version": "2012-10-17",
         "Statement": [
@@ -255,7 +255,7 @@ def test_add_stack_delete_policy_to_task_role(mock_stack, addon_type):
         ],
     }
 
-    add_stack_delete_policy_to_task_role("test-application", "development", addon_type)
+    add_stack_delete_policy_to_task_role("test-application", "development", addon_name)
 
     stack_resources = boto3.client("cloudformation").list_stack_resources(StackName=stack_name)[
         "StackResourceSummaries"
@@ -427,7 +427,7 @@ def test_start_conduit_with_custom_addon_name(
         "test-application", "development", addon_type, "custom-addon-name"
     )
     add_stack_delete_policy_to_task_role.assert_called_once_with(
-        "test-application", "development", addon_type
+        "test-application", "development", "custom-addon-name"
     )
     connect_to_addon_client_task.assert_called_once_with(
         "test-application", "development", "test-arn", "custom-addon-name"


### PR DESCRIPTION
Fix for a bug in the function to add delete policy to conduit CloudFormation stacks, which causes the command to fail when there's a custom addon name.