### PR TITLE
DBTP-590 - Update OpenSearch template to allow scaling without instance replacement

### DIFF
--- a/dbt_copilot_helper/templates/addons/env/opensearch.yml
+++ b/dbt_copilot_helper/templates/addons/env/opensearch.yml
@@ -85,7 +85,6 @@ Resources:
       ToPort: 443
       SourceSecurityGroupId: !Ref EnvironmentSecurityGroup
 
-  # Opensearch
   {{ addon_config.prefix }}OpenSearchDomain:
     Type: 'AWS::OpenSearchService::Domain'
     Properties:

--- a/dbt_copilot_helper/templates/addons/env/opensearch.yml
+++ b/dbt_copilot_helper/templates/addons/env/opensearch.yml
@@ -41,8 +41,7 @@ Mappings:
       EngineVersion: 'OpenSearch_2.3'
 
 Conditions:
-  {{ addon_config.prefix }}DisableHA: !Equals [!FindInMap [{{ addon_config.prefix }}EnvScalingConfigurationMap, !Ref Env, InstanceCount], 1]
-  {{ addon_config.prefix }}EnableHA: !Not [Condition: {{ addon_config.prefix }}DisableHA]
+  {{ addon_config.prefix }}EnableHA: !Not [!Equals [!FindInMap [{{ addon_config.prefix }}EnvScalingConfigurationMap, !Ref Env, InstanceCount], 1]]
 
 Resources:
   {{ addon_config.prefix }}OpenSearchSecret:
@@ -86,10 +85,9 @@ Resources:
       ToPort: 443
       SourceSecurityGroupId: !Ref EnvironmentSecurityGroup
 
-  # Single opensearch instance
+  # Opensearch
   {{ addon_config.prefix }}OpenSearchDomain:
     Type: 'AWS::OpenSearchService::Domain'
-    Condition: {{ addon_config.prefix }}DisableHA
     Properties:
       AccessPolicies:
         Version: '2012-10-17'
@@ -124,87 +122,21 @@ Resources:
         VolumeSize: !FindInMap [{{ addon_config.prefix }}EnvScalingConfigurationMap, !Ref Env, VolumeSize]
         VolumeType: gp2
       ClusterConfig:
-        DedicatedMasterEnabled: false
+        DedicatedMasterEnabled: !If [{{ addon_config.prefix }}EnableHA, !FindInMap [{{ addon_config.prefix }}EnvScalingConfigurationMap, !Ref Env, DedicatedMaster], false]
         InstanceCount: !FindInMap [{{ addon_config.prefix }}EnvScalingConfigurationMap, !Ref Env, InstanceCount]
         InstanceType: !FindInMap [{{ addon_config.prefix }}EnvScalingConfigurationMap, !Ref Env, InstanceType]
-        ZoneAwarenessEnabled: false
+        ZoneAwarenessEnabled: !If [{{ addon_config.prefix }}EnableHA, true, false]
+        ZoneAwarenessConfig: !If
+          - {{ addon_config.prefix }}EnableHA
+          - AvailabilityZoneCount: 2 #Fn::length always resolves to 1 despite there being subnets.
+          - !Ref "AWS::NoValue"
       VPCOptions:
         SecurityGroupIds:
           - !Ref {{ addon_config.prefix }}OpenSearchSecurityGroup
-        SubnetIds:
-          - !Select [0, !Split [ ',', !Ref PrivateSubnets ] ]
-      SoftwareUpdateOptions:
-        AutoSoftwareUpdateEnabled: true
-      LogPublishingOptions:
-        AUDIT_LOGS:
-          CloudWatchLogsLogGroupArn: !GetAtt {{ addon_config.prefix }}OpenSearchAuditLogGroup.Arn
-          Enabled: true
-        ES_APPLICATION_LOGS:
-          CloudWatchLogsLogGroupArn: !GetAtt {{ addon_config.prefix }}OpenSearchApplicationLogGroup.Arn
-          Enabled: true
-        SEARCH_SLOW_LOGS:
-          CloudWatchLogsLogGroupArn: !GetAtt {{ addon_config.prefix }}OpenSearchSlowSearchLogGroup.Arn
-          Enabled: true
-        INDEX_SLOW_LOGS:
-          CloudWatchLogsLogGroupArn: !GetAtt {{ addon_config.prefix }}OpenSearchSlowIndexLogGroup.Arn
-          Enabled: true
-      Tags:
-        - Key: Name
-          Value: !Sub 'copilot-${App}-${Env}-{{ addon_config.name }}-OpenSearch-Domain'
-        - Key: 'Copilot-Application'
-          Value: !Sub ${App}
-        - Key: 'Copilot-Environment'
-          Value: !Sub ${Env}
-
-  # An opensearch cluster
-  {{ addon_config.prefix }}OpenSearchDomainHA:
-    Type: 'AWS::OpenSearchService::Domain'
-    Condition: {{ addon_config.prefix }}EnableHA
-    Properties:
-      AccessPolicies:
-        Version: '2012-10-17'
-        Statement:
-        - Effect: Allow
-          Principal:
-            AWS: '*'
-          Action:
-          - 'es:ESHttp*'
-          Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/{{ (addon_config.name|replace("-", ""))[:15] }}*'
-      AdvancedSecurityOptions:
-        Enabled: true
-        InternalUserDatabaseEnabled: true
-        MasterUserOptions:
-          MasterUserName:
-            !Join [ "",  [ '{% raw %}{{resolve:secretsmanager:{% endraw %}', !Ref {{ addon_config.prefix }}OpenSearchSecret, "{% raw %}:SecretString:username}}{% endraw %}" ]]
-          MasterUserPassword:
-            !Join [ "",  [ '{% raw %}{{resolve:secretsmanager:{% endraw %}', !Ref {{ addon_config.prefix }}OpenSearchSecret, "{% raw %}:SecretString:password}}{% endraw %}" ]]
-      DomainEndpointOptions:
-        EnforceHTTPS: true
-        TLSSecurityPolicy: 'Policy-Min-TLS-1-2-2019-07'
-      EngineVersion: !FindInMap
-        - {{ addon_config.prefix }}EngineVersionMap
-        - !FindInMap [{{ addon_config.prefix }}EnvScalingConfigurationMap, !Ref Env, EngineVersion]
-        - EngineVersion
-      NodeToNodeEncryptionOptions:
-        Enabled: true
-      EncryptionAtRestOptions:
-        Enabled: true
-      EBSOptions:
-        EBSEnabled: true
-        VolumeSize: !FindInMap [{{ addon_config.prefix }}EnvScalingConfigurationMap, !Ref Env, VolumeSize]
-        VolumeType: gp2
-      ClusterConfig:
-        DedicatedMasterEnabled: !FindInMap [{{ addon_config.prefix }}EnvScalingConfigurationMap, !Ref Env, DedicatedMaster]
-        InstanceCount: !FindInMap [{{ addon_config.prefix }}EnvScalingConfigurationMap, !Ref Env, InstanceCount]
-        InstanceType: !FindInMap [{{ addon_config.prefix }}EnvScalingConfigurationMap, !Ref Env, InstanceType]
-        ZoneAwarenessEnabled: true
-        ZoneAwarenessConfig:
-          AvailabilityZoneCount: 2
-          #Fn::length always resolves to 1 despite there being subnets.
-      VPCOptions:
-        SecurityGroupIds:
-          - !Ref {{ addon_config.prefix }}OpenSearchSecurityGroup
-        SubnetIds: !Split [ ",", !Ref PrivateSubnets ]
+        SubnetIds: !If
+          - {{ addon_config.prefix }}EnableHA
+          - !Split [ ",", !Ref PrivateSubnets ]
+          - - !Select [ 0, !Split [ ',', !Ref PrivateSubnets ] ]
       SoftwareUpdateOptions:
         AutoSoftwareUpdateEnabled: true
       LogPublishingOptions:
@@ -235,10 +167,7 @@ Resources:
       Type: String
       Value: !Sub
         - "https://${username}:${password}@${url}"
-        - url: !If
-            - {{ addon_config.prefix }}EnableHA
-            - !GetAtt {{ addon_config.prefix }}OpenSearchDomainHA.DomainEndpoint
-            - !GetAtt {{ addon_config.prefix }}OpenSearchDomain.DomainEndpoint
+        - url: !GetAtt {{ addon_config.prefix }}OpenSearchDomain.DomainEndpoint
           username: !Join [ "",  [ '{% raw %}{{resolve:secretsmanager:{% endraw %}', !Ref {{ addon_config.prefix }}OpenSearchSecret, "{% raw %}:SecretString:username}}{% endraw %}" ]]
           password: !Join [ "",  [ '{% raw %}{{resolve:secretsmanager:{% endraw %}', !Ref {{ addon_config.prefix }}OpenSearchSecret, "{% raw %}:SecretString:password}}{% endraw %}" ]]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.90"
+version = "0.1.91"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-opensearch-longer.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-opensearch-longer.yml
@@ -85,7 +85,6 @@ Resources:
       ToPort: 443
       SourceSecurityGroupId: !Ref EnvironmentSecurityGroup
 
-  # Opensearch
   myOpensearchLongerOpenSearchDomain:
     Type: 'AWS::OpenSearchService::Domain'
     Properties:

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-opensearch-longer.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-opensearch-longer.yml
@@ -41,8 +41,7 @@ Mappings:
       EngineVersion: 'OpenSearch_2.3'
 
 Conditions:
-  myOpensearchLongerDisableHA: !Equals [!FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, InstanceCount], 1]
-  myOpensearchLongerEnableHA: !Not [Condition: myOpensearchLongerDisableHA]
+  myOpensearchLongerEnableHA: !Not [!Equals [!FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, InstanceCount], 1]]
 
 Resources:
   myOpensearchLongerOpenSearchSecret:
@@ -86,10 +85,9 @@ Resources:
       ToPort: 443
       SourceSecurityGroupId: !Ref EnvironmentSecurityGroup
 
-  # Single opensearch instance
+  # Opensearch
   myOpensearchLongerOpenSearchDomain:
     Type: 'AWS::OpenSearchService::Domain'
-    Condition: myOpensearchLongerDisableHA
     Properties:
       AccessPolicies:
         Version: '2012-10-17'
@@ -124,87 +122,21 @@ Resources:
         VolumeSize: !FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, VolumeSize]
         VolumeType: gp2
       ClusterConfig:
-        DedicatedMasterEnabled: false
+        DedicatedMasterEnabled: !If [myOpensearchLongerEnableHA, !FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, DedicatedMaster], false]
         InstanceCount: !FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, InstanceCount]
         InstanceType: !FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, InstanceType]
-        ZoneAwarenessEnabled: false
+        ZoneAwarenessEnabled: !If [myOpensearchLongerEnableHA, true, false]
+        ZoneAwarenessConfig: !If
+          - myOpensearchLongerEnableHA
+          - AvailabilityZoneCount: 2 #Fn::length always resolves to 1 despite there being subnets.
+          - !Ref "AWS::NoValue"
       VPCOptions:
         SecurityGroupIds:
           - !Ref myOpensearchLongerOpenSearchSecurityGroup
-        SubnetIds:
-          - !Select [0, !Split [ ',', !Ref PrivateSubnets ] ]
-      SoftwareUpdateOptions:
-        AutoSoftwareUpdateEnabled: true
-      LogPublishingOptions:
-        AUDIT_LOGS:
-          CloudWatchLogsLogGroupArn: !GetAtt myOpensearchLongerOpenSearchAuditLogGroup.Arn
-          Enabled: true
-        ES_APPLICATION_LOGS:
-          CloudWatchLogsLogGroupArn: !GetAtt myOpensearchLongerOpenSearchApplicationLogGroup.Arn
-          Enabled: true
-        SEARCH_SLOW_LOGS:
-          CloudWatchLogsLogGroupArn: !GetAtt myOpensearchLongerOpenSearchSlowSearchLogGroup.Arn
-          Enabled: true
-        INDEX_SLOW_LOGS:
-          CloudWatchLogsLogGroupArn: !GetAtt myOpensearchLongerOpenSearchSlowIndexLogGroup.Arn
-          Enabled: true
-      Tags:
-        - Key: Name
-          Value: !Sub 'copilot-${App}-${Env}-my-opensearch-longer-OpenSearch-Domain'
-        - Key: 'Copilot-Application'
-          Value: !Sub ${App}
-        - Key: 'Copilot-Environment'
-          Value: !Sub ${Env}
-
-  # An opensearch cluster
-  myOpensearchLongerOpenSearchDomainHA:
-    Type: 'AWS::OpenSearchService::Domain'
-    Condition: myOpensearchLongerEnableHA
-    Properties:
-      AccessPolicies:
-        Version: '2012-10-17'
-        Statement:
-        - Effect: Allow
-          Principal:
-            AWS: '*'
-          Action:
-          - 'es:ESHttp*'
-          Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/myopensearchlon*'
-      AdvancedSecurityOptions:
-        Enabled: true
-        InternalUserDatabaseEnabled: true
-        MasterUserOptions:
-          MasterUserName:
-            !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchLongerOpenSearchSecret, ":SecretString:username}}" ]]
-          MasterUserPassword:
-            !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchLongerOpenSearchSecret, ":SecretString:password}}" ]]
-      DomainEndpointOptions:
-        EnforceHTTPS: true
-        TLSSecurityPolicy: 'Policy-Min-TLS-1-2-2019-07'
-      EngineVersion: !FindInMap
-        - myOpensearchLongerEngineVersionMap
-        - !FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, EngineVersion]
-        - EngineVersion
-      NodeToNodeEncryptionOptions:
-        Enabled: true
-      EncryptionAtRestOptions:
-        Enabled: true
-      EBSOptions:
-        EBSEnabled: true
-        VolumeSize: !FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, VolumeSize]
-        VolumeType: gp2
-      ClusterConfig:
-        DedicatedMasterEnabled: !FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, DedicatedMaster]
-        InstanceCount: !FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, InstanceCount]
-        InstanceType: !FindInMap [myOpensearchLongerEnvScalingConfigurationMap, !Ref Env, InstanceType]
-        ZoneAwarenessEnabled: true
-        ZoneAwarenessConfig:
-          AvailabilityZoneCount: 2
-          #Fn::length always resolves to 1 despite there being subnets.
-      VPCOptions:
-        SecurityGroupIds:
-          - !Ref myOpensearchLongerOpenSearchSecurityGroup
-        SubnetIds: !Split [ ",", !Ref PrivateSubnets ]
+        SubnetIds: !If
+          - myOpensearchLongerEnableHA
+          - !Split [ ",", !Ref PrivateSubnets ]
+          - - !Select [ 0, !Split [ ',', !Ref PrivateSubnets ] ]
       SoftwareUpdateOptions:
         AutoSoftwareUpdateEnabled: true
       LogPublishingOptions:
@@ -235,10 +167,7 @@ Resources:
       Type: String
       Value: !Sub
         - "https://${username}:${password}@${url}"
-        - url: !If
-            - myOpensearchLongerEnableHA
-            - !GetAtt myOpensearchLongerOpenSearchDomainHA.DomainEndpoint
-            - !GetAtt myOpensearchLongerOpenSearchDomain.DomainEndpoint
+        - url: !GetAtt myOpensearchLongerOpenSearchDomain.DomainEndpoint
           username: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchLongerOpenSearchSecret, ":SecretString:username}}" ]]
           password: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchLongerOpenSearchSecret, ":SecretString:password}}" ]]
 

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-opensearch.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-opensearch.yml
@@ -85,7 +85,6 @@ Resources:
       ToPort: 443
       SourceSecurityGroupId: !Ref EnvironmentSecurityGroup
 
-  # Opensearch
   myOpensearchOpenSearchDomain:
     Type: 'AWS::OpenSearchService::Domain'
     Properties:

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-opensearch.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-opensearch.yml
@@ -41,8 +41,7 @@ Mappings:
       EngineVersion: 'OpenSearch_2.3'
 
 Conditions:
-  myOpensearchDisableHA: !Equals [!FindInMap [myOpensearchEnvScalingConfigurationMap, !Ref Env, InstanceCount], 1]
-  myOpensearchEnableHA: !Not [Condition: myOpensearchDisableHA]
+  myOpensearchEnableHA: !Not [!Equals [!FindInMap [myOpensearchEnvScalingConfigurationMap, !Ref Env, InstanceCount], 1]]
 
 Resources:
   myOpensearchOpenSearchSecret:
@@ -86,10 +85,9 @@ Resources:
       ToPort: 443
       SourceSecurityGroupId: !Ref EnvironmentSecurityGroup
 
-  # Single opensearch instance
+  # Opensearch
   myOpensearchOpenSearchDomain:
     Type: 'AWS::OpenSearchService::Domain'
-    Condition: myOpensearchDisableHA
     Properties:
       AccessPolicies:
         Version: '2012-10-17'
@@ -124,87 +122,21 @@ Resources:
         VolumeSize: !FindInMap [myOpensearchEnvScalingConfigurationMap, !Ref Env, VolumeSize]
         VolumeType: gp2
       ClusterConfig:
-        DedicatedMasterEnabled: false
+        DedicatedMasterEnabled: !If [myOpensearchEnableHA, !FindInMap [myOpensearchEnvScalingConfigurationMap, !Ref Env, DedicatedMaster], false]
         InstanceCount: !FindInMap [myOpensearchEnvScalingConfigurationMap, !Ref Env, InstanceCount]
         InstanceType: !FindInMap [myOpensearchEnvScalingConfigurationMap, !Ref Env, InstanceType]
-        ZoneAwarenessEnabled: false
+        ZoneAwarenessEnabled: !If [myOpensearchEnableHA, true, false]
+        ZoneAwarenessConfig: !If
+          - myOpensearchEnableHA
+          - AvailabilityZoneCount: 2 #Fn::length always resolves to 1 despite there being subnets.
+          - !Ref "AWS::NoValue"
       VPCOptions:
         SecurityGroupIds:
           - !Ref myOpensearchOpenSearchSecurityGroup
-        SubnetIds:
-          - !Select [0, !Split [ ',', !Ref PrivateSubnets ] ]
-      SoftwareUpdateOptions:
-        AutoSoftwareUpdateEnabled: true
-      LogPublishingOptions:
-        AUDIT_LOGS:
-          CloudWatchLogsLogGroupArn: !GetAtt myOpensearchOpenSearchAuditLogGroup.Arn
-          Enabled: true
-        ES_APPLICATION_LOGS:
-          CloudWatchLogsLogGroupArn: !GetAtt myOpensearchOpenSearchApplicationLogGroup.Arn
-          Enabled: true
-        SEARCH_SLOW_LOGS:
-          CloudWatchLogsLogGroupArn: !GetAtt myOpensearchOpenSearchSlowSearchLogGroup.Arn
-          Enabled: true
-        INDEX_SLOW_LOGS:
-          CloudWatchLogsLogGroupArn: !GetAtt myOpensearchOpenSearchSlowIndexLogGroup.Arn
-          Enabled: true
-      Tags:
-        - Key: Name
-          Value: !Sub 'copilot-${App}-${Env}-my-opensearch-OpenSearch-Domain'
-        - Key: 'Copilot-Application'
-          Value: !Sub ${App}
-        - Key: 'Copilot-Environment'
-          Value: !Sub ${Env}
-
-  # An opensearch cluster
-  myOpensearchOpenSearchDomainHA:
-    Type: 'AWS::OpenSearchService::Domain'
-    Condition: myOpensearchEnableHA
-    Properties:
-      AccessPolicies:
-        Version: '2012-10-17'
-        Statement:
-        - Effect: Allow
-          Principal:
-            AWS: '*'
-          Action:
-          - 'es:ESHttp*'
-          Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/myopensearch*'
-      AdvancedSecurityOptions:
-        Enabled: true
-        InternalUserDatabaseEnabled: true
-        MasterUserOptions:
-          MasterUserName:
-            !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchOpenSearchSecret, ":SecretString:username}}" ]]
-          MasterUserPassword:
-            !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchOpenSearchSecret, ":SecretString:password}}" ]]
-      DomainEndpointOptions:
-        EnforceHTTPS: true
-        TLSSecurityPolicy: 'Policy-Min-TLS-1-2-2019-07'
-      EngineVersion: !FindInMap
-        - myOpensearchEngineVersionMap
-        - !FindInMap [myOpensearchEnvScalingConfigurationMap, !Ref Env, EngineVersion]
-        - EngineVersion
-      NodeToNodeEncryptionOptions:
-        Enabled: true
-      EncryptionAtRestOptions:
-        Enabled: true
-      EBSOptions:
-        EBSEnabled: true
-        VolumeSize: !FindInMap [myOpensearchEnvScalingConfigurationMap, !Ref Env, VolumeSize]
-        VolumeType: gp2
-      ClusterConfig:
-        DedicatedMasterEnabled: !FindInMap [myOpensearchEnvScalingConfigurationMap, !Ref Env, DedicatedMaster]
-        InstanceCount: !FindInMap [myOpensearchEnvScalingConfigurationMap, !Ref Env, InstanceCount]
-        InstanceType: !FindInMap [myOpensearchEnvScalingConfigurationMap, !Ref Env, InstanceType]
-        ZoneAwarenessEnabled: true
-        ZoneAwarenessConfig:
-          AvailabilityZoneCount: 2
-          #Fn::length always resolves to 1 despite there being subnets.
-      VPCOptions:
-        SecurityGroupIds:
-          - !Ref myOpensearchOpenSearchSecurityGroup
-        SubnetIds: !Split [ ",", !Ref PrivateSubnets ]
+        SubnetIds: !If
+          - myOpensearchEnableHA
+          - !Split [ ",", !Ref PrivateSubnets ]
+          - - !Select [ 0, !Split [ ',', !Ref PrivateSubnets ] ]
       SoftwareUpdateOptions:
         AutoSoftwareUpdateEnabled: true
       LogPublishingOptions:
@@ -235,10 +167,7 @@ Resources:
       Type: String
       Value: !Sub
         - "https://${username}:${password}@${url}"
-        - url: !If
-            - myOpensearchEnableHA
-            - !GetAtt myOpensearchOpenSearchDomainHA.DomainEndpoint
-            - !GetAtt myOpensearchOpenSearchDomain.DomainEndpoint
+        - url: !GetAtt myOpensearchOpenSearchDomain.DomainEndpoint
           username: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchOpenSearchSecret, ":SecretString:username}}" ]]
           password: !Join [ "",  [ '{{resolve:secretsmanager:', !Ref myOpensearchOpenSearchSecret, ":SecretString:password}}" ]]
 


### PR DESCRIPTION
- Update OpenSearch template to change specific properties rather than conditionally defining a separate instance. This allows the instance count to change without CloudFormation replacing the resource
- Bump version number