### PR TITLE
Extra prod domain bug

### DIFF
--- a/dbt_copilot_helper/COMMANDS.md
+++ b/dbt_copilot_helper/COMMANDS.md
@@ -582,8 +582,8 @@ copilot-helper domain (configure|assign)
 
 [↩ Parent](#copilot-helper-domain)
 
-    Creates missing subdomains if they do not already exist and creates
-    certificates for those subdomains.
+    Creates subdomains if they do not exist and then creates certificates for
+    them.
 
 ## Usage
 

--- a/dbt_copilot_helper/COMMANDS.md
+++ b/dbt_copilot_helper/COMMANDS.md
@@ -582,8 +582,8 @@ copilot-helper domain (configure|assign)
 
 [↩ Parent](#copilot-helper-domain)
 
-    Creates missing subdomains (up to 2 levels deep) if they do not already
-    exist and creates certificates for those subdomains.
+    Creates missing subdomains if they do not already exist and creates
+    certificates for those subdomains.
 
 ## Usage
 

--- a/dbt_copilot_helper/COMMANDS.md
+++ b/dbt_copilot_helper/COMMANDS.md
@@ -589,7 +589,7 @@ copilot-helper domain (configure|assign)
 
 ```
 copilot-helper domain configure --domain-profile (dev|live) --project-profile <project_profile> 
-                                --base-domain <base_domain> [--env <env>] 
+                                --base-domain <base_domain> --env <env> 
 ```
 
 ## Options

--- a/dbt_copilot_helper/COMMANDS.md
+++ b/dbt_copilot_helper/COMMANDS.md
@@ -588,18 +588,14 @@ copilot-helper domain (configure|assign)
 ## Usage
 
 ```
-copilot-helper domain configure --domain-profile (dev|live) --project-profile <project_profile> 
-                                --base-domain <base_domain> --env <env> 
+copilot-helper domain configure --project-profile <project_profile> 
+                                --env <env> 
 ```
 
 ## Options
 
-- `--domain-profile <choice>`
-  - AWS account profile name for Route53 domains account
 - `--project-profile <text>`
   - AWS account profile name for certificates account
-- `--base-domain <text>`
-  - root domain
 - `--env <text>`
   - AWS Copilot environment name
 - `--help <boolean>` _Defaults to False._

--- a/dbt_copilot_helper/commands/dns.py
+++ b/dbt_copilot_helper/commands/dns.py
@@ -339,17 +339,17 @@ class InvalidDomainException(Exception):
     pass
 
 
-def _get_subdomains_from_base(base: list[str], subdomain: list[str]):
+def _get_subdomains_from_base(base: list[str], subdomain: list[str]) -> list[list[str]]:
     if base == subdomain:
         return []
     return [subdomain] + _get_subdomains_from_base(base, subdomain[1:])
 
 
-def get_required_subdomains(base_domain: str, subdomain: str):
+def get_required_subdomains(base_domain: str, subdomain: str) -> list[str]:
     """
     We only want to get subdomains up to 4 levels deep.
 
-    Prod base domains should be 3 levels deep so we should create up to one
+    Prod base domains should be 3 levels deep, so we should create up to one
     additional subdomain. Dev base domain is always "uktrade.digital" and should
     have the app and env subdomains created, so 4 levels in either case.
     """

--- a/dbt_copilot_helper/commands/dns.py
+++ b/dbt_copilot_helper/commands/dns.py
@@ -290,9 +290,9 @@ def create_hosted_zones(client, base_domain, subdomain):
 
 
 def _add_subdomain_ns_records_to_parent(client, domain_name, ns_records, parent_zone_id):
-    # Add NS records of subdomain to parent
+    # Add nameserver records of subdomain to parent
     nameservers = ns_records["NameServers"]
-    # append  . to make fqdn
+    # append . to make fully qualified domain name
     nameservers = [f"{nameserver}." for nameserver in nameservers]
     nameserver_resource_records = [{"Value": nameserver} for nameserver in nameservers]
     client.change_resource_record_sets(
@@ -536,8 +536,8 @@ def domain():
 )
 @click.option("--env", help="AWS Copilot environment name", required=True)
 def configure(project_profile, env):
-    """Creates missing subdomains if they do not already exist and creates
-    certificates for those subdomains."""
+    """Creates subdomains if they do not exist and then creates certificates for
+    them."""
 
     # If you need to reset to debug this command, you will need to delete any of the following
     # which have been created:

--- a/dbt_copilot_helper/commands/dns.py
+++ b/dbt_copilot_helper/commands/dns.py
@@ -28,7 +28,7 @@ from dbt_copilot_helper.utils.versioning import (
 AVAILABLE_DOMAINS = {
     "great.gov.uk": "live",
     "trade.gov.uk": "live",
-    "prod.uktrade.digital": "live",
+    "prod.uktrade.digital": "dev",
     "uktrade.digital": "dev",
 }
 AWS_CERT_REGION = "eu-west-2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.95"
+version = "0.1.96"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/conftest.py
+++ b/tests/copilot_helper/conftest.py
@@ -26,17 +26,13 @@ UTILS_FIXTURES_DIR = BASE_DIR / "tests" / "copilot_helper" / "utils" / "fixtures
 DOCS_DIR = BASE_DIR / "tests" / "copilot_helper" / "test-docs"
 
 # tell yaml to ignore CFN ! function prefixes
-yaml.add_multi_constructor(
-    "!", lambda loader, suffix, node: None, Loader=yaml.SafeLoader
-)
+yaml.add_multi_constructor("!", lambda loader, suffix, node: None, Loader=yaml.SafeLoader)
 
 
 @pytest.fixture
 def fakefs(fs):
     """Mock file system fixture with the templates and schemas dirs retained."""
-    fs.add_real_directory(
-        BASE_DIR / "dbt_copilot_helper/custom_resources", lazy_read=True
-    )
+    fs.add_real_directory(BASE_DIR / "dbt_copilot_helper/custom_resources", lazy_read=True)
     fs.add_real_directory(BASE_DIR / "dbt_copilot_helper/templates", lazy_read=True)
     fs.add_real_directory(BASE_DIR / "dbt_copilot_helper/schemas", lazy_read=True)
     fs.add_real_directory(FIXTURES_DIR, lazy_read=True)
@@ -45,18 +41,14 @@ def fakefs(fs):
     fs.add_real_file(BASE_DIR / "dbt_copilot_helper/addons-template-map.yml")
 
     # JSON Schema compatibility
-    fs.add_real_directory(
-        Path(jsonschema.__path__[0]) / "schemas/vocabularies", lazy_read=True
-    )
+    fs.add_real_directory(Path(jsonschema.__path__[0]) / "schemas/vocabularies", lazy_read=True)
 
     # To avoid 'Could not find a suitable TLS CA certificate bundle...' error
     fs.add_real_file(Path(certifi.__file__).parent / "cacert.pem")
 
     # For fakefs compatibility with moto
     fs.add_real_directory(Path(boto3.__file__).parent.joinpath("data"), lazy_read=True)
-    fs.add_real_directory(
-        Path(botocore.__file__).parent.joinpath("data"), lazy_read=True
-    )
+    fs.add_real_directory(Path(botocore.__file__).parent.joinpath("data"), lazy_read=True)
 
     # Add fake aws config file
     fs.add_real_file(
@@ -64,6 +56,35 @@ def fakefs(fs):
     )
 
     return fs
+
+
+@pytest.fixture(scope="function")
+def create_test_manifest(fakefs):
+    fakefs.create_file(
+        "copilot/manifest.yml",
+        contents="""
+environments:
+  dev:
+    http:
+      alias: v2.app.dev.uktrade.digital
+
+  staging:
+    http:
+      alias: v2.app.staging.uktrade.digital
+
+  prod1:
+    http:
+      alias: v2.app.prod.uktrade.digital
+
+  prod2:
+    http:
+      alias: v2.app.great.gov.uk
+
+  prod3:
+    http:
+      alias: app.trade.gov.uk
+""",
+    )
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -82,15 +103,9 @@ def mock_application():
             "222222222": boto3,
         }
         application = Application("test-application")
-        application.environments["development"] = Environment(
-            "development", "000000000", sessions
-        )
-        application.environments["staging"] = Environment(
-            "staging", "111111111", sessions
-        )
-        application.environments["production"] = Environment(
-            "production", "222222222", sessions
-        )
+        application.environments["development"] = Environment("development", "000000000", sessions)
+        application.environments["staging"] = Environment("staging", "111111111", sessions)
+        application.environments["production"] = Environment("production", "222222222", sessions)
 
         app_patch.return_value = application
 
@@ -100,9 +115,7 @@ def mock_application():
 @pytest.fixture(scope="function")
 def aws_credentials(monkeypatch):
     """Mocked AWS Credentials for moto."""
-    moto_credentials_file_path = (
-        Path(__file__).parent.absolute() / "dummy_aws_credentials"
-    )
+    moto_credentials_file_path = Path(__file__).parent.absolute() / "dummy_aws_credentials"
     monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(moto_credentials_file_path))
 
 
@@ -149,18 +162,16 @@ def mock_cluster_client_task(mocked_cluster):
             mocked_cluster_arn = mocked_cluster["cluster"]["clusterArn"]
 
             mocked_ec2_client = boto3.client("ec2")
-            mocked_ec2_images = mocked_ec2_client.describe_images(Owners=["amazon"])[
-                "Images"
-            ]
+            mocked_ec2_images = mocked_ec2_client.describe_images(Owners=["amazon"])["Images"]
             mocked_ec2_client.run_instances(
                 ImageId=mocked_ec2_images[0]["ImageId"],
                 MinCount=1,
                 MaxCount=1,
             )
             mocked_ec2_instances = boto3.client("ec2").describe_instances()
-            mocked_ec2_instance_id = mocked_ec2_instances["Reservations"][0][
-                "Instances"
-            ][0]["InstanceId"]
+            mocked_ec2_instance_id = mocked_ec2_instances["Reservations"][0]["Instances"][0][
+                "InstanceId"
+            ]
 
             mocked_ec2 = boto3.resource("ec2")
             mocked_ec2_instance = mocked_ec2.Instance(mocked_ec2_instance_id)
@@ -235,9 +246,7 @@ def mocked_pg_secret():
 
 @pytest.fixture(scope="function")
 def validate_version():
-    with patch(
-        "dbt_copilot_helper.utils.versioning.get_app_versions"
-    ) as get_app_versions:
+    with patch("dbt_copilot_helper.utils.versioning.get_app_versions") as get_app_versions:
         get_app_versions.return_value = ((1, 0, 0), (1, 0, 0))
         with patch(
             "dbt_copilot_helper.utils.versioning.validate_version_compatibility",
@@ -249,12 +258,8 @@ def validate_version():
 
 @pytest.fixture(scope="function")
 def mock_tool_versions():
-    with patch(
-        "dbt_copilot_helper.utils.versioning.get_app_versions"
-    ) as get_app_versions:
-        with patch(
-            "dbt_copilot_helper.utils.versioning.get_aws_versions"
-        ) as get_aws_versions:
+    with patch("dbt_copilot_helper.utils.versioning.get_app_versions") as get_app_versions:
+        with patch("dbt_copilot_helper.utils.versioning.get_aws_versions") as get_aws_versions:
             with patch(
                 "dbt_copilot_helper.utils.versioning.get_copilot_versions"
             ) as get_copilot_versions:
@@ -290,9 +295,7 @@ def mock_codestar_connection_response(app_name):
 def mock_codestar_connections_boto_client(mocked_boto3_client, connection_names):
     mocked_boto3_client.return_value = mocked_boto3_client
     mocked_boto3_client.list_connections.return_value = {
-        "Connections": [
-            mock_codestar_connection_response(name) for name in connection_names
-        ],
+        "Connections": [mock_codestar_connection_response(name) for name in connection_names],
         "NextToken": "not-interesting",
     }
 

--- a/tests/copilot_helper/test_command_dns.py
+++ b/tests/copilot_helper/test_command_dns.py
@@ -518,7 +518,6 @@ def test_get_required_subdomains_returns_the_expected_subdomains(
 @pytest.mark.parametrize(
     "domain, subdomain",
     [
-        ("xyz.com", "www.google.com"),
         ("uktrade.digital", "www.google.com"),
         ("uktrade.digital", "one.two.uktrade"),
         ("uktrade.digital", "one.two.digital"),
@@ -531,6 +530,11 @@ def test_get_required_subdomains_throws_exception_if_subdomain_and_base_domain_d
 ):
     with pytest.raises(InvalidDomainException, match=f"{subdomain} is not a subdomain of {domain}"):
         get_required_subdomains(domain, subdomain)
+
+
+def test_get_required_subdomains_throws_exception_if_base_domain_is_not_supported():
+    with pytest.raises(InvalidDomainException, match="xyz.com is not a supported base domain"):
+        get_required_subdomains("xyz.com", "myapp.xyz.com")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Ticket is: [DBTP-444](https://uktrade.atlassian.net/browse/DBTP-444)

Copied over from the ticket (agreed on a thread in slack):

- The dev base domain will always be uktrade.digital
- Prod base domains will always be one of: prod.uktrade.digital, great.gov.uk, trade.gov.uk
- For dev, subdomains will always be <name>.<env>.uktrade.digital
- For prod, subdomains will always be <name>.<base_domain. Deeper names will be added as records (such as `v2.app.trade.gov.uk`)
- base_domain can be inferred from the subdomain if we keep a dict of base_domains vs domain_profiles in the codebase.
- We don’t need the functionality to be able to pass in an entire domain_profile, so domain_profile can also be inferred from the subdomain. 
  - Note: this means we can remove both --base-domain and --domain-profile options from the command.
- For the certificates, we need to generate a cert for the largest hosted zone we have created (or already existed)

[DBTP-444]: https://uktrade.atlassian.net/browse/DBTP-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ