### PR TITLE
DBPT-589 conduit across accounts

### DIFF
--- a/dbt_copilot_helper/commands/conduit.py
+++ b/dbt_copilot_helper/commands/conduit.py
@@ -3,9 +3,10 @@ import re
 import subprocess
 import time
 
-import boto3
 import click
 
+from dbt_copilot_helper.utils.application import Application
+from dbt_copilot_helper.utils.application import load_application
 from dbt_copilot_helper.utils.click import ClickDocOptCommand
 from dbt_copilot_helper.utils.versioning import (
     check_copilot_helper_version_needs_update,
@@ -45,8 +46,8 @@ def normalise_string(to_normalise: str) -> str:
     return output.lower()
 
 
-def get_cluster_arn(app: str, env: str) -> str:
-    ecs_client = boto3.client("ecs")
+def get_cluster_arn(app: Application, env: str) -> str:
+    ecs_client = app.environments[env].session.client("ecs")
 
     for cluster_arn in ecs_client.list_clusters()["clusterArns"]:
         tags_response = ecs_client.list_tags_for_resource(resourceArn=cluster_arn)
@@ -57,7 +58,7 @@ def get_cluster_arn(app: str, env: str) -> str:
         cluster_key_found = False
 
         for tag in tags:
-            if tag["key"] == "copilot-application" and tag["value"] == app:
+            if tag["key"] == "copilot-application" and tag["value"] == app.name:
                 app_key_found = True
             if tag["key"] == "copilot-environment" and tag["value"] == env:
                 env_key_found = True
@@ -70,11 +71,11 @@ def get_cluster_arn(app: str, env: str) -> str:
     raise NoClusterConduitError
 
 
-def get_connection_secret_arn(app: str, env: str, name: str) -> str:
-    connection_secret_id = f"/copilot/{app}/{env}/secrets/{name}"
+def get_connection_secret_arn(app: Application, env: str, name: str) -> str:
+    secrets_manager = app.environments[env].session.client("secretsmanager")
+    ssm = app.environments[env].session.client("ssm")
 
-    secrets_manager = boto3.client("secretsmanager")
-    ssm = boto3.client("ssm")
+    connection_secret_id = f"/copilot/{app.name}/{env}/secrets/{name}"
 
     try:
         return ssm.get_parameter(Name=connection_secret_id, WithDecryption=False)["Parameter"][
@@ -91,12 +92,12 @@ def get_connection_secret_arn(app: str, env: str, name: str) -> str:
     raise SecretNotFoundConduitError(name)
 
 
-def create_addon_client_task(app: str, env: str, addon_type: str, addon_name: str):
+def create_addon_client_task(app: Application, env: str, addon_type: str, addon_name: str):
     connection_secret_arn = get_connection_secret_arn(app, env, addon_name.upper())
 
     subprocess.call(
-        f"copilot task run --app {app} --env {env} "
-        f"--task-group-name conduit-{app}-{env}-{normalise_string(addon_name)} "
+        f"copilot task run --app {app.name} --env {env} "
+        f"--task-group-name conduit-{app.name}-{env}-{normalise_string(addon_name)} "
         f"--image {CONDUIT_DOCKER_IMAGE_LOCATION}:{addon_type} "
         f"--secrets CONNECTION_SECRET={connection_secret_arn} "
         "--platform-os linux "
@@ -105,19 +106,19 @@ def create_addon_client_task(app: str, env: str, addon_type: str, addon_name: st
     )
 
 
-def addon_client_is_running(app: str, env: str, cluster_arn: str, addon_name: str) -> bool:
-    tasks = boto3.client("ecs").list_tasks(
+def addon_client_is_running(app: Application, env: str, cluster_arn: str, addon_name: str) -> bool:
+    ecs_client = app.environments[env].session.client("ecs")
+
+    tasks = ecs_client.list_tasks(
         cluster=cluster_arn,
         desiredStatus="RUNNING",
-        family=f"copilot-conduit-{app}-{env}-{normalise_string(addon_name)}",
+        family=f"copilot-conduit-{app.name}-{env}-{normalise_string(addon_name)}",
     )
 
     if not tasks["taskArns"]:
         return False
 
-    described_tasks = boto3.client("ecs").describe_tasks(
-        cluster=cluster_arn, tasks=tasks["taskArns"]
-    )
+    described_tasks = ecs_client.describe_tasks(cluster=cluster_arn, tasks=tasks["taskArns"])
 
     # The ExecuteCommandAgent often takes longer to start running than the task and without the
     # agent it's not possible to exec into a task.
@@ -130,7 +131,7 @@ def addon_client_is_running(app: str, env: str, cluster_arn: str, addon_name: st
     return False
 
 
-def connect_to_addon_client_task(app: str, env: str, cluster_arn: str, addon_name: str):
+def connect_to_addon_client_task(app: Application, env: str, cluster_arn: str, addon_name: str):
     tries = 0
     running = False
 
@@ -141,8 +142,8 @@ def connect_to_addon_client_task(app: str, env: str, cluster_arn: str, addon_nam
             running = True
             subprocess.call(
                 "copilot task exec "
-                f"--app {app} --env {env} "
-                f"--name conduit-{app}-{env}-{normalise_string(addon_name)} "
+                f"--app {app.name} --env {env} "
+                f"--name conduit-{app.name}-{env}-{normalise_string(addon_name)} "
                 f"--command bash",
                 shell=True,
             )
@@ -153,16 +154,20 @@ def connect_to_addon_client_task(app: str, env: str, cluster_arn: str, addon_nam
         raise CreateTaskTimeoutConduitError
 
 
-def add_stack_delete_policy_to_task_role(app: str, env: str, addon_name: str):
-    conduit_stack_name = f"task-conduit-{app}-{env}-{normalise_string(addon_name)}"
-    conduit_stack_resources = boto3.client("cloudformation").list_stack_resources(
+def add_stack_delete_policy_to_task_role(app: Application, env: str, addon_name: str):
+    session = app.environments[env].session
+    cloudformation_client = session.client("cloudformation")
+    iam_client = session.client("iam")
+
+    conduit_stack_name = f"task-conduit-{app.name}-{env}-{normalise_string(addon_name)}"
+    conduit_stack_resources = cloudformation_client.list_stack_resources(
         StackName=conduit_stack_name
     )["StackResourceSummaries"]
 
     for resource in conduit_stack_resources:
         if resource["LogicalResourceId"] == "DefaultTaskRole":
             task_role_name = resource["PhysicalResourceId"]
-            boto3.client("iam").put_role_policy(
+            iam_client.put_role_policy(
                 RoleName=task_role_name,
                 PolicyName="DeleteCloudFormationStack",
                 PolicyDocument=json.dumps(
@@ -184,14 +189,15 @@ def start_conduit(app: str, env: str, addon_type: str, addon_name: str = None):
     if addon_type not in CONDUIT_ADDON_TYPES:
         raise InvalidAddonTypeConduitError(addon_type)
 
-    cluster_arn = get_cluster_arn(app, env)
+    application = load_application(app)
+    cluster_arn = get_cluster_arn(application, env)
     addon_name = addon_name or addon_type
 
-    if not addon_client_is_running(app, env, cluster_arn, addon_name):
-        create_addon_client_task(app, env, addon_type, addon_name)
-        add_stack_delete_policy_to_task_role(app, env, addon_name)
+    if not addon_client_is_running(application, env, cluster_arn, addon_name):
+        create_addon_client_task(application, env, addon_type, addon_name)
+        add_stack_delete_policy_to_task_role(application, env, addon_name)
 
-    connect_to_addon_client_task(app, env, cluster_arn, addon_name)
+    connect_to_addon_client_task(application, env, cluster_arn, addon_name)
 
 
 @click.command(cls=ClickDocOptCommand)

--- a/dbt_copilot_helper/utils/application.py
+++ b/dbt_copilot_helper/utils/application.py
@@ -1,11 +1,80 @@
+import json
 from pathlib import Path
+from typing import Dict
 
+import boto3
 import yaml
 from yaml.parser import ParserError
 
+from dbt_copilot_helper.utils.aws import get_aws_session_or_abort
+from dbt_copilot_helper.utils.aws import get_profile_name_from_account_id
 from dbt_copilot_helper.utils.files import load_and_validate_config
 from dbt_copilot_helper.utils.messages import abort_with_error
 from dbt_copilot_helper.utils.validation import BOOTSTRAP_SCHEMA
+
+
+class Environment:
+    name: str
+    account_id: str
+    sessions: Dict[str, boto3.Session]
+
+    def __init__(self, name: str, account_id: str, sessions: Dict[str, boto3.Session]):
+        self.name = name
+        self.account_id = account_id
+        self.sessions = sessions
+
+    @property
+    def session(self):
+        if self.account_id not in self.sessions:
+            self.sessions[self.account_id] = get_aws_session_or_abort(
+                get_profile_name_from_account_id(self.account_id),
+            )
+
+        return self.sessions[self.account_id]
+
+
+class Application:
+    name: str
+    environments: Dict[str, Environment]
+
+    def __init__(self, name: str):
+        self.name = name
+        self.environments = {}
+
+    def __str__(self):
+        output = f"Application {self.name} with"
+
+        environments = [f"{env.name}:{env.account_id}" for env in self.environments.values()]
+
+        if environments:
+            return f"{output} environments {', '.join(environments)}"
+
+        return f"{output} no environments"
+
+    def __eq__(self, other):
+        return str(self) == str(other)
+
+
+def load_application(app: str = None) -> Application:
+    application = Application(app if app else get_application_name())
+    current_session = get_aws_session_or_abort()
+
+    response = current_session.client("ssm").get_parameters_by_path(
+        Path=f"/copilot/applications/{application.name}/environments",
+        Recursive=True,
+        WithDecryption=False,
+    )
+
+    sts_client = current_session.client("sts")
+    account_id = sts_client.get_caller_identity()["Account"]
+    sessions = {account_id: current_session}
+
+    application.environments = {
+        env["name"]: Environment(env["name"], env["accountID"], sessions)
+        for env in [json.loads(p["Value"]) for p in response["Parameters"]]
+    }
+
+    return application
 
 
 def get_application_name():

--- a/dbt_copilot_helper/utils/aws.py
+++ b/dbt_copilot_helper/utils/aws.py
@@ -29,8 +29,12 @@ def get_aws_session_or_abort(aws_profile: str) -> boto3.session.Session:
         exit()
 
     sts = session.client("sts")
+    account_id = None
+    user_id = None
     try:
-        sts.get_caller_identity()
+        response = sts.get_caller_identity()
+        account_id = response["Account"]
+        user_id = response["UserId"]
         click.secho("Credentials are valid.", fg="green")
     except botocore.exceptions.SSOTokenLoadError:
         click.secho(
@@ -51,20 +55,16 @@ def get_aws_session_or_abort(aws_profile: str) -> boto3.session.Session:
     if account_name:
         click.echo(
             click.style("Logged in with AWS account: ", fg="yellow")
-            + click.style(
-                f"{account_name[0]}/{sts.get_caller_identity()['Account']}", fg="white", bold=True
-            ),
+            + click.style(f"{account_name[0]}/{account_id}", fg="white", bold=True),
         )
     else:
         click.echo(
             click.style("Logged in with AWS account id: ", fg="yellow")
-            + click.style(f"{sts.get_caller_identity()['Account']}", fg="white", bold=True),
+            + click.style(f"{account_id}", fg="white", bold=True),
         )
     click.echo(
         click.style("User: ", fg="yellow")
-        + click.style(
-            f"{(sts.get_caller_identity()['UserId']).split(':')[-1]}\n", fg="white", bold=True
-        ),
+        + click.style(f"{user_id.split(':')[-1]}\n", fg="white", bold=True),
     )
 
     return session

--- a/dbt_copilot_helper/utils/aws.py
+++ b/dbt_copilot_helper/utils/aws.py
@@ -1,3 +1,4 @@
+import os
 from configparser import ConfigParser
 from pathlib import Path
 

--- a/dbt_copilot_helper/utils/aws.py
+++ b/dbt_copilot_helper/utils/aws.py
@@ -11,7 +11,9 @@ SSM_BASE_PATH = "/copilot/{app}/{env}/secrets/"
 SSM_PATH = "/copilot/{app}/{env}/secrets/{name}"
 
 
-def get_aws_session_or_abort(aws_profile: str) -> boto3.session.Session:
+def get_aws_session_or_abort(aws_profile: str = None) -> boto3.session.Session:
+    aws_profile = aws_profile if aws_profile else os.getenv("AWS_PROFILE")
+
     # Check that the aws profile exists and is set.
     click.secho(f"""Checking AWS connection for profile "{aws_profile}"...""", fg="cyan")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.91"
+version = "0.1.92"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/conftest.py
+++ b/tests/copilot_helper/conftest.py
@@ -57,6 +57,27 @@ def fakefs(fs):
     return fs
 
 
+@pytest.fixture(scope="function", autouse=True)
+def mock_application():
+    with patch("dbt_copilot_helper.utils.application.load_application") as app_patch:
+        from dbt_copilot_helper.utils.application import Application
+        from dbt_copilot_helper.utils.application import Environment
+
+        sessions = {
+            "000000000": boto3,
+            "111111111": boto3,
+            "222222222": boto3,
+        }
+        application = Application("test-application")
+        application.environments["development"] = Environment("development", "000000000", sessions)
+        application.environments["staging"] = Environment("staging", "111111111", sessions)
+        application.environments["production"] = Environment("production", "222222222", sessions)
+
+        app_patch.return_value = application
+
+        yield application
+
+
 @pytest.fixture(scope="function")
 def aws_credentials(monkeypatch):
     """Mocked AWS Credentials for moto."""

--- a/tests/copilot_helper/conftest.py
+++ b/tests/copilot_helper/conftest.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import boto3
+import botocore
 import certifi
 import jsonschema
 import pytest
@@ -30,16 +31,28 @@ yaml.add_multi_constructor("!", lambda loader, suffix, node: None, Loader=yaml.S
 @pytest.fixture
 def fakefs(fs):
     """Mock file system fixture with the templates and schemas dirs retained."""
-    fs.add_real_directory(BASE_DIR / "dbt_copilot_helper/custom_resources")
-    fs.add_real_directory(BASE_DIR / "dbt_copilot_helper/templates")
-    fs.add_real_directory(BASE_DIR / "dbt_copilot_helper/schemas")
+    fs.add_real_directory(BASE_DIR / "dbt_copilot_helper/custom_resources", lazy_read=True)
+    fs.add_real_directory(BASE_DIR / "dbt_copilot_helper/templates", lazy_read=True)
+    fs.add_real_directory(BASE_DIR / "dbt_copilot_helper/schemas", lazy_read=True)
+    fs.add_real_directory(FIXTURES_DIR, lazy_read=True)
     fs.add_real_file(BASE_DIR / "dbt_copilot_helper/addon-plans.yml")
     fs.add_real_file(BASE_DIR / "dbt_copilot_helper/default-addons.yml")
     fs.add_real_file(BASE_DIR / "dbt_copilot_helper/addons-template-map.yml")
-    fs.add_real_directory(Path(jsonschema.__path__[0]) / "schemas/vocabularies")
+
+    # JSON Schema compatibility
+    fs.add_real_directory(Path(jsonschema.__path__[0]) / "schemas/vocabularies", lazy_read=True)
 
     # To avoid 'Could not find a suitable TLS CA certificate bundle...' error
     fs.add_real_file(Path(certifi.__file__).parent / "cacert.pem")
+
+    # For fakefs compatibility with moto
+    fs.add_real_directory(Path(boto3.__file__).parent.joinpath("data"), lazy_read=True)
+    fs.add_real_directory(Path(botocore.__file__).parent.joinpath("data"), lazy_read=True)
+
+    # Add fake aws config file
+    fs.add_real_file(
+        FIXTURES_DIR / "dummy_aws_config.ini", True, Path.home().joinpath(".aws/config")
+    )
 
     return fs
 

--- a/tests/copilot_helper/fixtures/dummy_aws_config.ini
+++ b/tests/copilot_helper/fixtures/dummy_aws_config.ini
@@ -1,0 +1,17 @@
+[profile development]
+sso_start_url = https://testing-copilot.awsapps.com/start
+sso_region = eu-west-2
+sso_account_id = 000000000
+sso_role_name = AdministratorAccess
+
+[profile staging]
+sso_start_url = https://testing-copilot.awsapps.com/start
+sso_region = eu-west-2
+sso_account_id = 111111111
+sso_role_name = AdministratorAccess
+
+[profile production]
+sso_start_url = https://testing-copilot.awsapps.com/start
+sso_region = eu-west-2
+sso_account_id = 222222222
+sso_role_name = AdministratorAccess

--- a/tests/copilot_helper/test_command_check_cloudformation.py
+++ b/tests/copilot_helper/test_command_check_cloudformation.py
@@ -55,7 +55,6 @@ def application_under_test(copilot_directory):
 def test_check_cloudformation_with_no_args_summarises_all_successes(
     app_with_valid_cf_template, copilot_directory: Path
 ) -> None:
-    print(copilot_directory)
     result = CliRunner().invoke(
         check_cloudformation_command, args=["--directory", copilot_directory]
     )

--- a/tests/copilot_helper/test_copilot_helper.py
+++ b/tests/copilot_helper/test_copilot_helper.py
@@ -2,11 +2,11 @@ import re
 
 from click.testing import CliRunner
 
-from copilot_helper import copilot_helper
-
 
 class TestCopilotHelperCli:
     def test_check_version(self):
+        from copilot_helper import copilot_helper
+
         result = CliRunner().invoke(copilot_helper, ["--version"])
 
         name, version = result.output.split()
@@ -16,6 +16,8 @@ class TestCopilotHelperCli:
         assert (re.compile(r"^\d+(\.\d+){2,}$")).match(version)
 
     def test_sub_commands(self):
+        from copilot_helper import copilot_helper
+
         assert list(copilot_helper.commands.keys()) == [
             "bootstrap",
             "check-cloudformation",

--- a/tests/copilot_helper/utils/test_application.py
+++ b/tests/copilot_helper/utils/test_application.py
@@ -1,7 +1,16 @@
+import json
 from pathlib import Path
+from unittest import TestCase
 from unittest.mock import patch
 
+import boto3
+from moto import mock_ssm
+from moto import mock_sts
+
+from dbt_copilot_helper.utils.application import Application
+from dbt_copilot_helper.utils.application import Environment
 from dbt_copilot_helper.utils.application import get_application_name
+from dbt_copilot_helper.utils.application import load_application
 
 
 def test_getting_an_application_name_from_bootstrap(fakefs):
@@ -26,3 +35,94 @@ def test_getting_an_application_name_from_workspace(fakefs):
 def test_getting_an_application_name_when_no_workspace_or_bootstrap(abort_with_error, fakefs):
     get_application_name()
     abort_with_error.assert_called_with("No valid bootstrap.yml or copilot/.workspace file found")
+
+
+@patch("dbt_copilot_helper.utils.application.get_profile_name_from_account_id", return_value="foo")
+@patch("dbt_copilot_helper.utils.application.get_aws_session_or_abort", return_value=boto3)
+class EnvironmentTest(TestCase):
+    def test_environment_session(self, get_aws_session_or_abort, get_profile_name_from_account_id):
+        environment = Environment("test", "999999999", {})
+
+        self.assertEqual(environment.name, "test")
+        self.assertEqual(environment.account_id, "999999999")
+
+        get_aws_session_or_abort.assert_not_called()
+        get_profile_name_from_account_id.assert_not_called()
+
+        self.assertEqual(environment.session, boto3)
+
+        get_aws_session_or_abort.assert_called_with("foo")
+        get_profile_name_from_account_id.assert_called_once()
+
+
+@patch("dbt_copilot_helper.utils.application.get_profile_name_from_account_id", return_value="foo")
+@patch("dbt_copilot_helper.utils.application.get_aws_session_or_abort", return_value=boto3)
+class ApplicationTest(TestCase):
+    def test_empty_application(self, get_aws_session_or_abort, get_profile_name_from_account_id):
+        application = Application("test")
+
+        self.assertEqual(application.name, "test")
+        self.assertEqual(application.environments, {})
+        self.assertEqual(str(application), "Application test with no environments")
+
+    def test_application_with_environments(
+        self, get_aws_session_or_abort, get_profile_name_from_account_id
+    ):
+        application = Application("test")
+        environment_one = Environment("one", "111111111", {})
+        environment_two = Environment("two", "222222222", {})
+        application.environments["one"] = environment_one
+        application.environments["two"] = environment_two
+
+        self.assertEqual(application.name, "test")
+        self.assertEqual(
+            str(application), "Application test with environments one:111111111, two:222222222"
+        )
+
+    @mock_ssm
+    @mock_sts
+    @patch("dbt_copilot_helper.utils.application.get_application_name", return_value="test")
+    def test_loading_an_application_with_environments(
+        self, get_application_name, get_aws_session_or_abort, get_profile_name_from_account_id
+    ):
+        ssm_client = boto3.client("ssm")
+        ssm_client.put_parameter(
+            Name=f"/copilot/applications/test/environments/one",
+            Value=json.dumps(
+                {
+                    "name": "one",
+                    "accountID": "111111111",
+                }
+            ),
+            Type="String",
+        )
+        ssm_client.put_parameter(
+            Name=f"/copilot/applications/test/environments/two",
+            Value=json.dumps(
+                {
+                    "name": "two",
+                    "accountID": "222222222",
+                }
+            ),
+            Type="String",
+        )
+
+        application = load_application()
+
+        self.assertEqual(application.name, "test")
+        self.assertEqual(
+            str(application), "Application test with environments one:111111111, two:222222222"
+        )
+        self.assertEqual(application.environments["one"].session, boto3)
+        self.assertEqual(application.environments["two"].session, boto3)
+
+    @mock_ssm
+    @mock_sts
+    @patch("dbt_copilot_helper.utils.application.get_application_name", return_value="test")
+    def test_loading_an_empty_application(
+        self, get_application_name, get_aws_session_or_abort, get_profile_name_from_account_id
+    ):
+        application = load_application()
+
+        self.assertEqual(application.name, "test")
+        self.assertEqual(str(application), "Application test with no environments")


### PR DESCRIPTION
- Allow conduit to connect to addons provisioned in accounts other than the main application account (production for example).
- Implementation of an `Application` class and loader allowing easy and lazy-loading session access.
- Minor tweak to `fakefs` fixture to lazy-load real directories.