### PR TITLE
DBTP-464 Fix no accounts in pipelines config raising error

### DIFF
--- a/dbt_copilot_helper/templates/pipelines/codebase/overrides/stack.ts
+++ b/dbt_copilot_helper/templates/pipelines/codebase/overrides/stack.ts
@@ -134,7 +134,7 @@ export class TransformedStack extends cdk.Stack {
                     ],
                 }),
             },
-            repositoryPolicyText: {
+            repositoryPolicyText: this.pipelinesFile.accounts ? {
                 Statement: [
                     {
                         Effect: "Allow",
@@ -152,7 +152,7 @@ export class TransformedStack extends cdk.Stack {
                         ]
                     }
                 ]
-            }
+            } : undefined,
         });
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.92"
+version = "0.1.93"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"


### PR DESCRIPTION
- Fix an error when no accounts are configured (for situations where there is only one account in the application).
- Remove repetition when creating required pipeline stages for existing and newly created pipelines.
- Push up a codebase configuration including information about all pipelines that deploy that codebase.