### PR TITLE
Codebase list command

### DIFF
--- a/dbt_copilot_helper/COMMANDS.md
+++ b/dbt_copilot_helper/COMMANDS.md
@@ -9,6 +9,7 @@
 - [copilot-helper check-cloudformation lint](#copilot-helper-check-cloudformation-lint)
 - [copilot-helper codebase](#copilot-helper-codebase)
 - [copilot-helper codebase prepare](#copilot-helper-codebase-prepare)
+- [copilot-helper codebase list](#copilot-helper-codebase-list)
 - [copilot-helper codebase build](#copilot-helper-codebase-build)
 - [copilot-helper codebase deploy](#copilot-helper-codebase-deploy)
 - [copilot-helper codebuild](#copilot-helper-codebuild)
@@ -221,7 +222,7 @@ copilot-helper check-cloudformation lint [-d <directory>]
 ## Usage
 
 ```
-copilot-helper codebase (prepare|build|deploy) 
+copilot-helper codebase (prepare|list|build|deploy) 
 ```
 
 ## Options
@@ -233,6 +234,7 @@ copilot-helper codebase (prepare|build|deploy)
 
 - [`build` ↪](#copilot-helper-codebase-build)
 - [`deploy` ↪](#copilot-helper-codebase-deploy)
+- [`list` ↪](#copilot-helper-codebase-list)
 - [`prepare` ↪](#copilot-helper-codebase-prepare)
 
 # copilot-helper codebase prepare
@@ -249,6 +251,25 @@ copilot-helper codebase prepare
 
 ## Options
 
+- `--help <boolean>` _Defaults to False._
+  - Show this message and exit.
+
+# copilot-helper codebase list
+
+[↩ Parent](#copilot-helper-codebase)
+
+    List available codebases for the application.
+
+## Usage
+
+```
+copilot-helper codebase list --app <app> 
+```
+
+## Options
+
+- `--app <text>`
+  - AWS application name
 - `--help <boolean>` _Defaults to False._
   - Show this message and exit.
 

--- a/dbt_copilot_helper/COMMANDS.md
+++ b/dbt_copilot_helper/COMMANDS.md
@@ -263,13 +263,15 @@ copilot-helper codebase prepare
 ## Usage
 
 ```
-copilot-helper codebase list --app <app> 
+copilot-helper codebase list --app <app> [--with-images] 
 ```
 
 ## Options
 
 - `--app <text>`
   - AWS application name
+- `--with-images <boolean>` _Defaults to False._
+  - List up to the last 10 images tagged for this codebase
 - `--help <boolean>` _Defaults to False._
   - Show this message and exit.
 

--- a/dbt_copilot_helper/commands/codebase.py
+++ b/dbt_copilot_helper/commands/codebase.py
@@ -84,19 +84,37 @@ def prepare():
 
 @codebase.command()
 @click.option("--app", help="AWS application name", required=True)
+def list(app):
+    """List available codebases for the application."""
+    application = load_application_or_abort(app)
+    ssm_client = boto3.client("ssm")
+    parameters = ssm_client.get_parameters_by_path(
+        Path=f"/copilot/applications/{application.name}/codebases",
+        Recursive=True,
+    )["Parameters"]
+
+    codebases = [json.loads(p["Value"]) for p in parameters]
+
+    if not codebases:
+        click.secho(f'No codebases found for application "{application.name}"', fg="red")
+        raise click.Abort
+
+    click.echo("The following codebases are available:")
+
+    for codebase in codebases:
+        click.echo(f"- {codebase['name']} (https://github.com/{codebase['repository']})")
+
+    click.echo("")
+
+
+@codebase.command()
+@click.option("--app", help="AWS application name", required=True)
 @click.option("--codebase", help="GitHub codebase name", required=True)
 @click.option("--commit", help="GitHub commit hash", required=True)
 def build(app, codebase, commit):
     """Trigger a CodePipeline pipeline based build."""
 
-    try:
-        load_application(app)
-    except ApplicationNotFoundError:
-        click.secho(
-            f"""The account "{os.environ.get("AWS_PROFILE")}" does not contain the application "{app}"; ensure you have set the environment variable "AWS_PROFILE" correctly.""",
-            fg="red",
-        )
-        raise click.Abort
+    load_application_or_abort(app)
 
     check_if_commit_exists = subprocess.run(
         ["git", "branch", "-r", "--contains", f"{commit}"], capture_output=True, text=True
@@ -165,6 +183,17 @@ def deploy(app, env, codebase, commit):
     return click.echo("Your deployment was not triggered.")
 
 
+def load_application_or_abort(app: str) -> Application:
+    try:
+        return load_application(app)
+    except ApplicationNotFoundError:
+        click.secho(
+            f"""The account "{os.environ.get("AWS_PROFILE")}" does not contain the application "{app}"; ensure you have set the environment variable "AWS_PROFILE" correctly.""",
+            fg="red",
+        )
+        raise click.Abort
+
+
 def check_image_exists(application: Application, codebase: str, commit: str):
     ecr_client = boto3.client("ecr")
     try:
@@ -204,14 +233,8 @@ def check_codebase_exists(application: Application, codebase: str):
 
 
 def load_application_with_environment(app, env):
-    try:
-        application = load_application(app)
-    except ApplicationNotFoundError:
-        click.secho(
-            f"""The account "{os.environ.get("AWS_PROFILE")}" does not contain the application "{app}"; ensure you have set the environment variable "AWS_PROFILE" correctly.""",
-            fg="red",
-        )
-        raise click.Abort
+    application = load_application_or_abort(app)
+
     if not application.environments.get(env):
         click.secho(
             f"""The environment "{env}" either does not exist or has not been deployed.""",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.100"
+version = "0.1.101"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.101"
+version = "0.1.102"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"


### PR DESCRIPTION
Adds new command:

```shell
copilot-helper codebase list --app <app> [--with-images] 
```

Will list codebases associated with an application. The optional flag `--with-images` will list, with links, the commits for which an image has been built.

Example output for demodjango:

```console
copilot-helper codebase list --app demodjango --with-images
Checking AWS connection for profile "foo"...
Credentials are valid.
Logged in with AWS account id: xxxxxxxxx
User: xxxxxxxxxxx

The following codebases are available:
- application (https://github.com/uktrade/demodjango)
  - https://github.com/uktrade/demodjango/commit/ee4a82c - published: 2023-11-30 15:39:43+00:00
  - https://github.com/uktrade/demodjango/commit/0f3e90f - published: 2023-11-09 10:58:49+00:00
  - https://github.com/uktrade/demodjango/commit/d269d51 - published: 2023-11-08 17:20:34+00:00
  - https://github.com/uktrade/demodjango/commit/42b8197 - published: 2023-11-08 16:54:46+00:00
  - https://github.com/uktrade/demodjango/commit/6ed19b2 - published: 2023-11-06 15:36:12+00:00
  - https://github.com/uktrade/demodjango/commit/dce17cf - published: 2023-11-02 16:51:23+00:00
  - https://github.com/uktrade/demodjango/commit/68ce4c8 - published: 2023-11-02 08:53:21+00:00
  - https://github.com/uktrade/demodjango/commit/e9fe194 - published: 2023-11-02 08:12:31+00:00
  - https://github.com/uktrade/demodjango/commit/57c0a08 - published: 2023-11-01 17:37:02+00:00
```