### PR TITLE
Add service level patching for renaming service log group name

### DIFF
--- a/dbt_copilot_helper/commands/bootstrap.py
+++ b/dbt_copilot_helper/commands/bootstrap.py
@@ -47,6 +47,14 @@ def get_paas_env_vars(client: CloudFoundryClient, paas: str) -> dict:
     return dict(env_vars)
 
 
+def _generate_svc_overrides(base_path, templates, name):
+    click.echo("\n>>> Generating service overrides\n")
+    overrides_path = base_path.joinpath(f"copilot/{name}/overrides")
+    overrides_path.mkdir(parents=True, exist_ok=True)
+    overrides_file = overrides_path.joinpath("cfn.patches.yml")
+    overrides_file.write_text(templates.get_template("svc/overrides/cfn.patches.yml").render())
+
+
 @click.group(chain=True, cls=ClickDocOptGroup)
 def bootstrap():
     check_copilot_helper_version_needs_update()
@@ -94,6 +102,7 @@ def make_config(directory="."):
         )
         name = service["name"]
         (base_path / f"copilot/{name}/addons/").mkdir(parents=True, exist_ok=True)
+        _generate_svc_overrides(base_path, templates, name)
 
         if "secrets_from" in service:
             # Copy secrets from the app referred to in the "secrets_from" key

--- a/dbt_copilot_helper/templates/svc/overrides/cfn.patches.yml
+++ b/dbt_copilot_helper/templates/svc/overrides/cfn.patches.yml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /Resources/LogGroup/Properties/LogGroupName
+  value: !Sub '/copilot/${AppName}/${EnvName}/${WorkloadName}'

--- a/dbt_copilot_helper/templates/svc/overrides/cfn.patches.yml
+++ b/dbt_copilot_helper/templates/svc/overrides/cfn.patches.yml
@@ -1,3 +1,4 @@
 - op: replace
   path: /Resources/LogGroup/Properties/LogGroupName
   value: !Sub '/copilot/${AppName}/${EnvName}/${WorkloadName}'
+  

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.104"
+version = "0.1.105"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"


### PR DESCRIPTION
Small change to bootstrap to include service level cfn patching to rename log group name with hypens to /'s