### PR TITLE
DBTP-625 - Update ALB log bucket name

### DIFF
--- a/dbt_copilot_helper/templates/env/manifest.yml
+++ b/dbt_copilot_helper/templates/env/manifest.yml
@@ -11,7 +11,7 @@ type: Environment
 http:
   public:
     access_logs:
-      bucket_name: dbt-alb-logs
+      bucket_name: dbt-access-logs
       prefix: {{ app_name }}/{{ name }}
 {% if certificate_arn %}
     certificates:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.105"
+version = "0.1.106"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/fixtures/make_addons/config/copilot/environments/development/manifest.yml
+++ b/tests/copilot_helper/fixtures/make_addons/config/copilot/environments/development/manifest.yml
@@ -11,7 +11,7 @@ type: Environment
 http:
   public:
     access_logs:
-      bucket_name: dbt-alb-logs
+      bucket_name: dbt-access-logs
       prefix: test-app/development
 
     certificates:

--- a/tests/copilot_helper/fixtures/newenv_environment_manifest.yml
+++ b/tests/copilot_helper/fixtures/newenv_environment_manifest.yml
@@ -34,7 +34,7 @@ network:
 http:
   public:
     access_logs:
-      bucket_name: dbt-alb-logs
+      bucket_name: dbt-access-logs
       prefix: test-app/newenv
 
     certificates:

--- a/tests/copilot_helper/fixtures/production_environment_manifest.yml
+++ b/tests/copilot_helper/fixtures/production_environment_manifest.yml
@@ -11,7 +11,7 @@ type: Environment
 http:
   public:
     access_logs:
-      bucket_name: dbt-alb-logs
+      bucket_name: dbt-access-logs
       prefix: test-app/production
 
     certificates:

--- a/tests/copilot_helper/fixtures/test_environment_manifest.yml
+++ b/tests/copilot_helper/fixtures/test_environment_manifest.yml
@@ -11,7 +11,7 @@ type: Environment
 http:
   public:
     access_logs:
-      bucket_name: dbt-alb-logs
+      bucket_name: dbt-access-logs
       prefix: test-app/test
 
     certificates:


### PR DESCRIPTION
Update ALB log bucket name to `dbt-access-logs` to match bucket in central logging account