### PR TITLE
Multiple domain bugfix

### DIFF
--- a/dbt_copilot_helper/commands/dns.py
+++ b/dbt_copilot_helper/commands/dns.py
@@ -385,12 +385,12 @@ def validate_subdomains(subdomains: list[str]) -> None:
 
 
 def get_base_domain(subdomains: list[str]) -> str:
-    matching_domains = []
+    matching_domains = set()
     domains_by_length = sorted(AVAILABLE_DOMAINS.keys(), key=lambda d: len(d), reverse=True)
     for subdomain in subdomains:
         for domain_name in domains_by_length:
             if subdomain.endswith(f".{domain_name}"):
-                matching_domains.append(domain_name)
+                matching_domains.add(domain_name)
                 break
 
     if len(matching_domains) > 1:
@@ -403,7 +403,7 @@ def get_base_domain(subdomains: list[str]) -> str:
             f"No base domains were found for subdomains: {ordered_subdomains}"
         )
 
-    return matching_domains[0]
+    return matching_domains.pop()
 
 
 def get_certificate_zone_id(hosted_zones):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.108"
+version = "0.1.109"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/test_command_dns.py
+++ b/tests/copilot_helper/test_command_dns.py
@@ -701,6 +701,12 @@ def test_get_base_domain_raises_exception_when_multiple_base_domains_found():
         get_base_domain(["v2.web.trade.gov.uk", "v2.web.great.gov.uk"])
 
 
+def test_get_base_domain_does_not_raise_exception_when_multiple_of_the_same_base_domains_found():
+    assert "trade.gov.uk" == get_base_domain(
+        ["static.web.trade.gov.uk", "internal.web.trade.gov.uk"]
+    )
+
+
 def test_get_base_domain_raises_exception_when_no_base_domains_found():
     with pytest.raises(
         InvalidDomainException,


### PR DESCRIPTION
When multiple domains were present with the same base domain, the tool would error. This fixes it so that it only errors when the base domains are different.