### PR TITLE
Bugfix for the file uploader permission issue

### DIFF
--- a/dbt_copilot_helper/templates/addons/env/s3.yml
+++ b/dbt_copilot_helper/templates/addons/env/s3.yml
@@ -132,13 +132,17 @@ Resources:
                   - 's3:PutObject'
                   - 's3:DeleteObject'
                 Resource:
-                  - !Sub ${ dwS3BucketBucket.Arn }/*
+                  - !Sub ${ {{ addon_config.prefix }}Bucket.Arn }/*
               - Effect: Allow
                 Action:
                   - 'logs:CreateLogGroup'
                   - 'logs:CreateLogStream'
                   - 'logs:PutLogEvents'
                 Resource: 'arn:aws:logs:*:*:*'
+              - Effect: Allow
+                Action:
+                  - 'kms:GenerateDataKey'
+                Resource: !GetAtt {{ addon_config.prefix }}KMSKey.Arn
 
 {% for s3object in addon_config.objects %}
   {{ addon_config.prefix }}S3Object{{ loop.index0 }}:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.109"
+version = "0.1.110"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-s3-bucket-with-an-object.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-s3-bucket-with-an-object.yml
@@ -203,13 +203,17 @@ Resources:
                   - 's3:PutObject'
                   - 's3:DeleteObject'
                 Resource:
-                  - !Sub ${ dwS3BucketBucket.Arn }/*
+                  - !Sub ${ myS3BucketWithAnObjectBucket.Arn }/*
               - Effect: Allow
                 Action:
                   - 'logs:CreateLogGroup'
                   - 'logs:CreateLogStream'
                   - 'logs:PutLogEvents'
                 Resource: 'arn:aws:logs:*:*:*'
+              - Effect: Allow
+                Action:
+                  - 'kms:GenerateDataKey'
+                Resource: !GetAtt myS3BucketWithAnObjectKMSKey.Arn
 
 
   myS3BucketWithAnObjectS3Object0:


### PR DESCRIPTION
The object-uploader-policy that we have to allow the uploader lambda to encrypt the objects did not have the required kms:GenerateDataKey permission. This fixes that issue.