### PR TITLE
DBTP-620 load balancer maintenance pages

### DIFF
--- a/copilot_helper.py
+++ b/copilot_helper.py
@@ -14,6 +14,7 @@ from dbt_copilot_helper.commands.conduit import conduit as conduit_commands
 from dbt_copilot_helper.commands.config import config as config_commands
 from dbt_copilot_helper.commands.copilot import copilot as copilot_commands
 from dbt_copilot_helper.commands.dns import domain as domain_commands
+from dbt_copilot_helper.commands.environment import environment as environment_commands
 from dbt_copilot_helper.commands.pipeline import pipeline as pipeline_commands
 from dbt_copilot_helper.commands.svc import svc as svc_commands
 from dbt_copilot_helper.commands.waf import waf as waf_commands
@@ -37,6 +38,7 @@ copilot_helper.add_command(conduit_commands)
 copilot_helper.add_command(config_commands)
 copilot_helper.add_command(copilot_commands)
 copilot_helper.add_command(domain_commands)
+copilot_helper.add_command(environment_commands)
 copilot_helper.add_command(pipeline_commands)
 copilot_helper.add_command(svc_commands)
 copilot_helper.add_command(waf_commands)

--- a/dbt_copilot_helper/COMMANDS.md
+++ b/dbt_copilot_helper/COMMANDS.md
@@ -28,6 +28,9 @@
 - [copilot-helper domain](#copilot-helper-domain)
 - [copilot-helper domain configure](#copilot-helper-domain-configure)
 - [copilot-helper domain assign](#copilot-helper-domain-assign)
+- [copilot-helper environment](#copilot-helper-environment)
+- [copilot-helper environment offline](#copilot-helper-environment-offline)
+- [copilot-helper environment online](#copilot-helper-environment-online)
 - [copilot-helper pipeline](#copilot-helper-pipeline)
 - [copilot-helper pipeline generate](#copilot-helper-pipeline-generate)
 - [copilot-helper svc](#copilot-helper-svc)
@@ -61,6 +64,7 @@ copilot-helper <command> [--version]
 - [`config` ↪](#copilot-helper-config)
 - [`copilot` ↪](#copilot-helper-copilot)
 - [`domain` ↪](#copilot-helper-domain)
+- [`environment` ↪](#copilot-helper-environment)
 - [`pipeline` ↪](#copilot-helper-pipeline)
 - [`svc` ↪](#copilot-helper-svc)
 - [`waf` ↪](#copilot-helper-waf)
@@ -703,6 +707,72 @@ copilot-helper domain assign --app <app> --env <env> --svc <svc>
   - AWS account profile name for Route53 domains account
 - `--project-profile <text>`
   - AWS account profile name for application account
+- `--help <boolean>` _Defaults to False._
+  - Show this message and exit.
+
+# copilot-helper environment
+
+[↩ Parent](#copilot-helper)
+
+    Commands affecting environments.
+
+## Usage
+
+```
+copilot-helper environment (offline|online) 
+```
+
+## Options
+
+- `--help <boolean>` _Defaults to False._
+  - Show this message and exit.
+
+## Commands
+
+- [`offline` ↪](#copilot-helper-environment-offline)
+- [`online` ↪](#copilot-helper-environment-online)
+
+# copilot-helper environment offline
+
+[↩ Parent](#copilot-helper-environment)
+
+    Take load-balanced web services offline with a maintenance page.
+
+## Usage
+
+```
+copilot-helper environment offline --app <app> --env <env> [--template (default|migration)] 
+```
+
+## Options
+
+- `--app <text>`
+
+- `--env <text>`
+
+- `--template <choice>` _Defaults to default._
+  - The maintenance page you wish to put up.
+- `--help <boolean>` _Defaults to False._
+  - Show this message and exit.
+
+# copilot-helper environment online
+
+[↩ Parent](#copilot-helper-environment)
+
+    Remove a maintenance page from an environment.
+
+## Usage
+
+```
+copilot-helper environment online --app <app> --env <env> 
+```
+
+## Options
+
+- `--app <text>`
+
+- `--env <text>`
+
 - `--help <boolean>` _Defaults to False._
   - Show this message and exit.
 

--- a/dbt_copilot_helper/commands/environment.py
+++ b/dbt_copilot_helper/commands/environment.py
@@ -1,5 +1,6 @@
 import re
 from pathlib import Path
+from typing import Union
 
 import boto3
 import click
@@ -153,7 +154,7 @@ def find_load_balancer(session: boto3.Session, app: str, env: str) -> str:
     return load_balancer_arn
 
 
-def find_https_listener(session: boto3.Session, app: str, env: str):
+def find_https_listener(session: boto3.Session, app: str, env: str) -> str:
     load_balancer_arn = find_load_balancer(session, app, env)
     lb_client = session.client("elbv2")
     listeners = lb_client.describe_listeners(LoadBalancerArn=load_balancer_arn)["Listeners"]
@@ -171,7 +172,7 @@ def find_https_listener(session: boto3.Session, app: str, env: str):
     return listener_arn
 
 
-def get_maintenance_page(session: boto3.Session, listener_arn: str) -> str | None:
+def get_maintenance_page(session: boto3.Session, listener_arn: str) -> Union[str, None]:
     lb_client = session.client("elbv2")
 
     rules = lb_client.describe_rules(ListenerArn=listener_arn)["Rules"]
@@ -234,7 +235,7 @@ def add_maintenance_page(session: boto3.Session, listener_arn: str, template: st
     )
 
 
-def get_maintenance_page_template(template):
+def get_maintenance_page_template(template) -> str:
     template_contents = (
         Path(__file__)
         .parent.parent.joinpath(

--- a/dbt_copilot_helper/commands/environment.py
+++ b/dbt_copilot_helper/commands/environment.py
@@ -1,0 +1,260 @@
+import re
+from pathlib import Path
+
+import boto3
+import click
+
+from dbt_copilot_helper.utils.application import load_application
+from dbt_copilot_helper.utils.click import ClickDocOptGroup
+from dbt_copilot_helper.utils.versioning import (
+    check_copilot_helper_version_needs_update,
+)
+
+AVAILABLE_TEMPLATES = ["default", "migration"]
+
+
+@click.group(cls=ClickDocOptGroup)
+def environment():
+    """Commands affecting environments."""
+    check_copilot_helper_version_needs_update()
+
+
+@environment.command
+@click.option("--app", type=str, required=True)
+@click.option("--env", type=str, required=True)
+@click.option(
+    "--template",
+    type=click.Choice(AVAILABLE_TEMPLATES),
+    default="default",
+    help="The maintenance page you wish to put up.",
+)
+def offline(app, env, template):
+    """Take load-balanced web services offline with a maintenance page."""
+    application = load_application(app)
+    application_environment = application.environments.get(env)
+
+    if not application_environment:
+        click.secho(
+            f"The environment {env} was not found in the application {app}. "
+            f"It either does not exist, or has not been deployed.",
+            fg="red",
+        )
+        raise click.Abort
+
+    try:
+        https_listener = find_https_listener(application_environment.session, app, env)
+        current_maintenance_page = get_maintenance_page(
+            application_environment.session, https_listener
+        )
+        remove_current_maintenance_page = False
+        if current_maintenance_page:
+            remove_current_maintenance_page = click.confirm(
+                f"There is currently a '{current_maintenance_page}' maintenance page for the {env} "
+                f"environment in {app}.\nWould you like to replace it with a '{template}' "
+                f"maintenance page?"
+            )
+            if not remove_current_maintenance_page:
+                raise click.Abort
+
+        if remove_current_maintenance_page or click.confirm(
+            f"You are about to enable the '{template}' maintenance page for the {env} "
+            f"environment in {app}.\nWould you like to continue?"
+        ):
+            if current_maintenance_page and remove_current_maintenance_page:
+                remove_maintenance_page(application_environment.session, https_listener)
+
+            add_maintenance_page(application_environment.session, https_listener, template)
+            click.secho(
+                f"Maintenance page '{template}' added for environment {env} in application {app}",
+                fg="green",
+            )
+        else:
+            raise click.Abort
+
+    except LoadBalancerNotFoundError:
+        click.secho(
+            f"No load balancer found for environment {env} in the application {app}.", fg="red"
+        )
+        raise click.Abort
+
+    except ListenerNotFoundError:
+        click.secho(
+            f"No HTTPS listener found for environment {env} in the application {app}.", fg="red"
+        )
+        raise click.Abort
+
+
+@environment.command
+@click.option("--app", type=str, required=True)
+@click.option("--env", type=str, required=True)
+def online(app, env):
+    """Remove a maintenance page from an environment."""
+    application = load_application(app)
+    application_environment = application.environments.get(env)
+
+    if not application_environment:
+        click.secho(
+            f"The environment {env} was not found in the application {app}. "
+            f"It either does not exist, or has not been deployed.",
+            fg="red",
+        )
+        raise click.Abort
+
+    try:
+        https_listener = find_https_listener(application_environment.session, app, env)
+        current_maintenance_page = get_maintenance_page(
+            application_environment.session, https_listener
+        )
+        if not current_maintenance_page:
+            click.secho("There is no current maintenance page to remove", fg="red")
+            raise click.Abort
+
+        if not click.confirm(
+            f"There is currently a '{current_maintenance_page}' maintenance page, "
+            f"would you like to remove it?"
+        ):
+            raise click.Abort
+
+        remove_maintenance_page(application_environment.session, https_listener)
+        click.secho(
+            f"Maintenance page removed from environment {env} in application {app}", fg="green"
+        )
+
+    except LoadBalancerNotFoundError:
+        click.secho(
+            f"No load balancer found for environment {env} in the application {app}.", fg="red"
+        )
+        raise click.Abort
+
+    except ListenerNotFoundError:
+        click.secho(
+            f"No HTTPS listener found for environment {env} in the application {app}.", fg="red"
+        )
+        raise click.Abort
+
+
+def find_load_balancer(session: boto3.Session, app: str, env: str) -> str:
+    lb_client = session.client("elbv2")
+
+    describe_response = lb_client.describe_load_balancers()
+    load_balancers = [lb["LoadBalancerArn"] for lb in describe_response["LoadBalancers"]]
+
+    load_balancers = lb_client.describe_tags(ResourceArns=load_balancers)["TagDescriptions"]
+
+    load_balancer_arn = None
+    for lb in load_balancers:
+        tags = {t["Key"]: t["Value"] for t in lb["Tags"]}
+        if tags.get("copilot-application") == app and tags.get("copilot-environment") == env:
+            load_balancer_arn = lb["ResourceArn"]
+
+    if not load_balancer_arn:
+        raise LoadBalancerNotFoundError()
+
+    return load_balancer_arn
+
+
+def find_https_listener(session: boto3.Session, app: str, env: str):
+    load_balancer_arn = find_load_balancer(session, app, env)
+    lb_client = session.client("elbv2")
+    listeners = lb_client.describe_listeners(LoadBalancerArn=load_balancer_arn)["Listeners"]
+
+    listener_arn = None
+
+    try:
+        listener_arn = next(l["ListenerArn"] for l in listeners if l["Protocol"] == "HTTPS")
+    except StopIteration:
+        pass
+
+    if not listener_arn:
+        raise ListenerNotFoundError()
+
+    return listener_arn
+
+
+def get_maintenance_page(session: boto3.Session, listener_arn: str) -> str | None:
+    lb_client = session.client("elbv2")
+
+    rules = lb_client.describe_rules(ListenerArn=listener_arn)["Rules"]
+    rules = lb_client.describe_tags(ResourceArns=[r["RuleArn"] for r in rules])["TagDescriptions"]
+
+    maintenance_page_type = None
+    for rule in rules:
+        tags = {t["Key"]: t["Value"] for t in rule["Tags"]}
+        if tags.get("name") == "MaintenancePage":
+            maintenance_page_type = tags.get("type")
+
+    return maintenance_page_type
+
+
+def remove_maintenance_page(session: boto3.Session, listener_arn: str):
+    lb_client = session.client("elbv2")
+
+    rules = lb_client.describe_rules(ListenerArn=listener_arn)["Rules"]
+    rules = lb_client.describe_tags(ResourceArns=[r["RuleArn"] for r in rules])["TagDescriptions"]
+
+    current_rule_arn = None
+    for rule in rules:
+        tags = {t["Key"]: t["Value"] for t in rule["Tags"]}
+        if tags.get("name") == "MaintenancePage":
+            current_rule_arn = rule["ResourceArn"]
+
+    if not current_rule_arn:
+        raise ListenerRuleNotFoundError()
+
+    lb_client.delete_rule(RuleArn=current_rule_arn)
+
+
+def add_maintenance_page(session: boto3.Session, listener_arn: str, template: str = "default"):
+    lb_client = session.client("elbv2")
+    maintenance_page_content = get_maintenance_page_template(template)
+
+    lb_client.create_rule(
+        ListenerArn=listener_arn,
+        Priority=1,
+        Conditions=[
+            {
+                "Field": "path-pattern",
+                "PathPatternConfig": {"Values": ["/*"]},
+            }
+        ],
+        Actions=[
+            {
+                "Type": "fixed-response",
+                "FixedResponseConfig": {
+                    "StatusCode": "503",
+                    "ContentType": "text/html",
+                    "MessageBody": maintenance_page_content,
+                },
+            }
+        ],
+        Tags=[
+            {"Key": "name", "Value": "MaintenancePage"},
+            {"Key": "type", "Value": template},
+        ],
+    )
+
+
+def get_maintenance_page_template(template):
+    template_contents = (
+        Path(__file__)
+        .parent.parent.joinpath(
+            f"templates/svc/maintenance_pages/{template}.html",
+        )
+        .read_text()
+        .replace("\n", "")
+    )
+
+    # [^\S]\s+ - Remove any space that is not preceded by a non-space character.
+    return re.sub(r"[^\S]\s+", "", template_contents)
+
+
+class LoadBalancerNotFoundError(Exception):
+    pass
+
+
+class ListenerNotFoundError(Exception):
+    pass
+
+
+class ListenerRuleNotFoundError(Exception):
+    pass

--- a/dbt_copilot_helper/templates/svc/maintenance_pages/default.html
+++ b/dbt_copilot_helper/templates/svc/maintenance_pages/default.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en-GB">
+<head>
+    <title>We'll be back soon... | DBT</title>
+    <link rel="stylesheet"
+          href="https://sso.trade.gov.uk/static/stylesheets/sso.css">
+</head>
+<body class="govuk-template__body">
+<header class="govuk-header" role="banner" data-module="govuk-header">
+    <div class="govuk-header__container govuk-width-container">
+        <div class="govuk-header__logo"></div>
+    </div>
+</header>
+<div class="govuk-width-container">
+    <main class="govuk-main-wrapper" id="main-content" role="main">
+        <h1 class="govuk-heading-l">Service Unavailable</h1>
+        <p class="govuk-body-l">The service is currently unavailable. Don't worry, we'll be back soon.</p>
+    </main>
+</div>
+</body>
+</html>

--- a/dbt_copilot_helper/templates/svc/maintenance_pages/migration.html
+++ b/dbt_copilot_helper/templates/svc/maintenance_pages/migration.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en-GB">
+<head>
+    <title>We'll be back soon... | DBT</title>
+    <link rel="stylesheet"
+          href="https://sso.trade.gov.uk/static/stylesheets/sso.css">
+</head>
+<body class="govuk-template__body">
+<header class="govuk-header " role="banner" data-module="govuk-header">
+    <div class="govuk-header__container govuk-width-container">
+        <div class="govuk-header__logo"></div>
+    </div>
+</header>
+<div class="govuk-width-container">
+    <main class="govuk-main-wrapper" id="main-content" role="main">
+        <h1 class="govuk-heading-l">Scheduled Maintenance</h1>
+        <p class="govuk-body-l">
+            The service is currently unavailable. Don't worry, we'll be back by the end of the day.
+        </p>
+    </main>
+</div>
+</body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.110"
+version = "0.1.111"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/test_command_environment.py
+++ b/tests/copilot_helper/test_command_environment.py
@@ -1,0 +1,487 @@
+from unittest.mock import ANY
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+
+class TestEnvironmentOfflineCommand:
+    @patch(
+        "dbt_copilot_helper.commands.environment.find_https_listener", return_value="https_listener"
+    )
+    @patch("dbt_copilot_helper.commands.environment.get_maintenance_page", return_value=None)
+    @patch("dbt_copilot_helper.commands.environment.add_maintenance_page", return_value=None)
+    def test_successful_offline(
+        self, add_maintenance_page, get_maintenance_page, find_https_listener, mock_application
+    ):
+        from dbt_copilot_helper.commands.environment import offline
+
+        result = CliRunner().invoke(
+            offline, ["--app", "test-application", "--env", "development"], input="y\n"
+        )
+
+        assert (
+            "You are about to enable the 'default' maintenance page for the development "
+            "environment in test-application."
+        ) in result.output
+        assert "Would you like to continue? [y/N]: y" in result.output
+
+        find_https_listener.assert_called_with(ANY, "test-application", "development")
+        get_maintenance_page.assert_called_with(ANY, "https_listener")
+        add_maintenance_page.assert_called_with(ANY, "https_listener", "default")
+
+        assert (
+            "Maintenance page 'default' added for environment development in "
+            "application test-application"
+        ) in result.output
+
+    @patch(
+        "dbt_copilot_helper.commands.environment.find_https_listener", return_value="https_listener"
+    )
+    @patch("dbt_copilot_helper.commands.environment.get_maintenance_page", return_value=None)
+    @patch("dbt_copilot_helper.commands.environment.add_maintenance_page", return_value=None)
+    def test_successful_offline_with_custom_template(
+        self, add_maintenance_page, get_maintenance_page, find_https_listener, mock_application
+    ):
+        from dbt_copilot_helper.commands.environment import offline
+
+        result = CliRunner().invoke(
+            offline,
+            ["--app", "test-application", "--env", "development", "--template", "migration"],
+            input="y\n",
+        )
+
+        assert (
+            "You are about to enable the 'migration' maintenance page for the development "
+            "environment in test-application."
+        ) in result.output
+        assert "Would you like to continue? [y/N]: y" in result.output
+
+        find_https_listener.assert_called_with(ANY, "test-application", "development")
+        get_maintenance_page.assert_called_with(ANY, "https_listener")
+        add_maintenance_page.assert_called_with(ANY, "https_listener", "migration")
+
+        assert (
+            "Maintenance page 'migration' added for environment development in "
+            "application test-application"
+        ) in result.output
+
+    @patch(
+        "dbt_copilot_helper.commands.environment.find_https_listener", return_value="https_listener"
+    )
+    @patch(
+        "dbt_copilot_helper.commands.environment.get_maintenance_page", return_value="maintenance"
+    )
+    @patch("dbt_copilot_helper.commands.environment.remove_maintenance_page", return_value=None)
+    @patch("dbt_copilot_helper.commands.environment.add_maintenance_page", return_value=None)
+    def test_successful_offline_when_already_offline(
+        self,
+        add_maintenance_page,
+        remove_maintenance_page,
+        get_maintenance_page,
+        find_https_listener,
+        mock_application,
+    ):
+        from dbt_copilot_helper.commands.environment import offline
+
+        result = CliRunner().invoke(
+            offline, ["--app", "test-application", "--env", "development"], input="y\n"
+        )
+
+        assert (
+            "There is currently a 'maintenance' maintenance page for the development "
+            "environment in test-application."
+        ) in result.output
+        assert (
+            "Would you like to replace it with a 'default' maintenance page? [y/N]: y"
+            in result.output
+        )
+
+        find_https_listener.assert_called_with(ANY, "test-application", "development")
+        get_maintenance_page.assert_called_with(ANY, "https_listener")
+        remove_maintenance_page.assert_called_with(ANY, "https_listener")
+        add_maintenance_page.assert_called_with(ANY, "https_listener", "default")
+
+        assert (
+            "Maintenance page 'default' added for environment development in "
+            "application test-application"
+        ) in result.output
+
+    @patch("dbt_copilot_helper.commands.environment.find_https_listener")
+    @patch("dbt_copilot_helper.commands.environment.get_maintenance_page")
+    @patch("dbt_copilot_helper.commands.environment.remove_maintenance_page")
+    @patch("dbt_copilot_helper.commands.environment.add_maintenance_page")
+    def test_offline_an_environment_when_load_balancer_not_found(
+        self,
+        add_maintenance_page,
+        remove_maintenance_page,
+        get_maintenance_page,
+        find_https_listener,
+        mock_application,
+    ):
+        from dbt_copilot_helper.commands.environment import LoadBalancerNotFoundError
+        from dbt_copilot_helper.commands.environment import offline
+
+        find_https_listener.side_effect = LoadBalancerNotFoundError()
+
+        result = CliRunner().invoke(
+            offline, ["--app", "test-application", "--env", "development"], input="y\n"
+        )
+
+        assert (
+            "No load balancer found for environment development in the application "
+            "test-application."
+        ) in result.output
+        assert "Aborted!" in result.output
+
+        find_https_listener.assert_called_with(ANY, "test-application", "development")
+        get_maintenance_page.assert_not_called()
+        remove_maintenance_page.assert_not_called()
+
+    @patch("dbt_copilot_helper.commands.environment.find_https_listener")
+    @patch("dbt_copilot_helper.commands.environment.get_maintenance_page")
+    @patch("dbt_copilot_helper.commands.environment.remove_maintenance_page")
+    @patch("dbt_copilot_helper.commands.environment.add_maintenance_page")
+    def test_offline_an_environment_when_listener_not_found(
+        self,
+        add_maintenance_page,
+        remove_maintenance_page,
+        get_maintenance_page,
+        find_https_listener,
+        mock_application,
+    ):
+        from dbt_copilot_helper.commands.environment import ListenerNotFoundError
+        from dbt_copilot_helper.commands.environment import offline
+
+        find_https_listener.side_effect = ListenerNotFoundError()
+
+        result = CliRunner().invoke(
+            offline, ["--app", "test-application", "--env", "development"], input="y\n"
+        )
+
+        assert (
+            "No HTTPS listener found for environment development in the application "
+            "test-application."
+        ) in result.output
+        assert "Aborted!" in result.output
+
+        find_https_listener.assert_called_with(ANY, "test-application", "development")
+        get_maintenance_page.assert_not_called()
+        remove_maintenance_page.assert_not_called()
+        add_maintenance_page.assert_not_called()
+
+    @patch("dbt_copilot_helper.commands.environment.find_https_listener")
+    @patch("dbt_copilot_helper.commands.environment.get_maintenance_page")
+    @patch("dbt_copilot_helper.commands.environment.remove_maintenance_page")
+    @patch("dbt_copilot_helper.commands.environment.add_maintenance_page")
+    def test_offline_an_environment_when_https_listener_not_found(
+        self,
+        add_maintenance_page,
+        remove_maintenance_page,
+        get_maintenance_page,
+        find_https_listener,
+        mock_application,
+    ):
+        from dbt_copilot_helper.commands.environment import LoadBalancerNotFoundError
+        from dbt_copilot_helper.commands.environment import online
+
+        find_https_listener.side_effect = LoadBalancerNotFoundError()
+
+        result = CliRunner().invoke(
+            online, ["--app", "test-application", "--env", "development"], input="y\n"
+        )
+
+        assert (
+            "No load balancer found for environment development in the application "
+            "test-application."
+        ) in result.output
+        assert "Aborted!" in result.output
+
+        find_https_listener.assert_called_with(ANY, "test-application", "development")
+        get_maintenance_page.assert_not_called()
+        remove_maintenance_page.assert_not_called()
+        add_maintenance_page.assert_not_called()
+
+
+class TestEnvironmentOnlineCommand:
+    @patch(
+        "dbt_copilot_helper.commands.environment.find_https_listener", return_value="https_listener"
+    )
+    @patch("dbt_copilot_helper.commands.environment.get_maintenance_page", return_value="default")
+    @patch("dbt_copilot_helper.commands.environment.remove_maintenance_page", return_value=None)
+    def test_successful_online(
+        self, remove_maintenance_page, get_maintenance_page, find_https_listener, mock_application
+    ):
+        from dbt_copilot_helper.commands.environment import online
+
+        result = CliRunner().invoke(
+            online, ["--app", "test-application", "--env", "development"], input="y\n"
+        )
+
+        assert (
+            "There is currently a 'default' maintenance page, would you like to remove it? "
+            "[y/N]: y"
+        ) in result.output
+
+        find_https_listener.assert_called_with(ANY, "test-application", "development")
+        get_maintenance_page.assert_called_with(ANY, "https_listener")
+        remove_maintenance_page.assert_called_with(ANY, "https_listener")
+
+        assert (
+            "Maintenance page removed from environment development in "
+            "application test-application"
+        ) in result.output
+
+    @patch(
+        "dbt_copilot_helper.commands.environment.find_https_listener", return_value="https_listener"
+    )
+    @patch("dbt_copilot_helper.commands.environment.get_maintenance_page", return_value=None)
+    @patch("dbt_copilot_helper.commands.environment.remove_maintenance_page", return_value=None)
+    def test_online_an_environment_that_is_not_offline(
+        self, remove_maintenance_page, get_maintenance_page, find_https_listener, mock_application
+    ):
+        from dbt_copilot_helper.commands.environment import online
+
+        result = CliRunner().invoke(
+            online, ["--app", "test-application", "--env", "development"], input="y\n"
+        )
+
+        assert "There is no current maintenance page to remove" in result.output
+
+        find_https_listener.assert_called_with(ANY, "test-application", "development")
+        get_maintenance_page.assert_called_with(ANY, "https_listener")
+        remove_maintenance_page.assert_not_called()
+
+    @patch("dbt_copilot_helper.commands.environment.find_https_listener")
+    @patch("dbt_copilot_helper.commands.environment.get_maintenance_page")
+    @patch("dbt_copilot_helper.commands.environment.remove_maintenance_page")
+    def test_online_an_environment_when_listener_not_found(
+        self, remove_maintenance_page, get_maintenance_page, find_https_listener, mock_application
+    ):
+        from dbt_copilot_helper.commands.environment import ListenerNotFoundError
+        from dbt_copilot_helper.commands.environment import online
+
+        find_https_listener.side_effect = ListenerNotFoundError()
+
+        result = CliRunner().invoke(
+            online, ["--app", "test-application", "--env", "development"], input="y\n"
+        )
+
+        assert (
+            "No HTTPS listener found for environment development in the application "
+            "test-application."
+        ) in result.output
+        assert "Aborted!" in result.output
+
+        find_https_listener.assert_called_with(ANY, "test-application", "development")
+        get_maintenance_page.assert_not_called()
+        remove_maintenance_page.assert_not_called()
+
+    @patch("dbt_copilot_helper.commands.environment.find_https_listener")
+    @patch("dbt_copilot_helper.commands.environment.get_maintenance_page")
+    @patch("dbt_copilot_helper.commands.environment.remove_maintenance_page")
+    def test_online_an_environment_when_load_balancer_not_found(
+        self, remove_maintenance_page, get_maintenance_page, find_https_listener, mock_application
+    ):
+        from dbt_copilot_helper.commands.environment import LoadBalancerNotFoundError
+        from dbt_copilot_helper.commands.environment import online
+
+        find_https_listener.side_effect = LoadBalancerNotFoundError()
+
+        result = CliRunner().invoke(
+            online, ["--app", "test-application", "--env", "development"], input="y\n"
+        )
+
+        assert (
+            "No load balancer found for environment development in the application "
+            "test-application."
+        ) in result.output
+        assert "Aborted!" in result.output
+
+        find_https_listener.assert_called_with(ANY, "test-application", "development")
+        get_maintenance_page.assert_not_called()
+        remove_maintenance_page.assert_not_called()
+
+
+class TestFindLoadBalancer:
+    def test_when_no_load_balancer_exists(self):
+        from dbt_copilot_helper.commands.environment import LoadBalancerNotFoundError
+        from dbt_copilot_helper.commands.environment import find_load_balancer
+
+        boto_mock = MagicMock()
+        boto_mock.client().describe_load_balancers.return_value = {"LoadBalancers": []}
+        with pytest.raises(LoadBalancerNotFoundError):
+            find_load_balancer(boto_mock, "test-application", "development")
+
+    def test_when_a_load_balancer_exists(self):
+        from dbt_copilot_helper.commands.environment import find_load_balancer
+
+        boto_mock = MagicMock()
+        boto_mock.client().describe_load_balancers.return_value = {
+            "LoadBalancers": [{"LoadBalancerArn": "lb_arn"}]
+        }
+        boto_mock.client().describe_tags.return_value = {
+            "TagDescriptions": [
+                {
+                    "ResourceArn": "lb_arn",
+                    "Tags": [
+                        {"Key": "copilot-application", "Value": "test-application"},
+                        {"Key": "copilot-environment", "Value": "development"},
+                    ],
+                }
+            ]
+        }
+
+        lb_arn = find_load_balancer(boto_mock, "test-application", "development")
+        assert "lb_arn" == lb_arn
+
+
+class TestFindHTTPSListener:
+    @patch("dbt_copilot_helper.commands.environment.find_load_balancer", return_value="lb_arn")
+    def test_when_no_https_listener_present(self, find_load_balancer):
+        from dbt_copilot_helper.commands.environment import ListenerNotFoundError
+        from dbt_copilot_helper.commands.environment import find_https_listener
+
+        boto_mock = MagicMock()
+        boto_mock.client().describe_listeners.return_value = {"Listeners": []}
+        with pytest.raises(ListenerNotFoundError):
+            find_https_listener(boto_mock, "test-application", "development")
+
+    @patch("dbt_copilot_helper.commands.environment.find_load_balancer", return_value="lb_arn")
+    def test_when_https_listener_present(self, find_load_balancer):
+        from dbt_copilot_helper.commands.environment import find_https_listener
+
+        boto_mock = MagicMock()
+        boto_mock.client().describe_listeners.return_value = {
+            "Listeners": [{"ListenerArn": "listener_arn", "Protocol": "HTTPS"}]
+        }
+
+        listener_arn = find_https_listener(boto_mock, "test-application", "development")
+        assert "listener_arn" == listener_arn
+
+
+class TestGetMaintenancePage:
+    def test_when_environment_online(self):
+        from dbt_copilot_helper.commands.environment import get_maintenance_page
+
+        boto_mock = MagicMock()
+        boto_mock.client().describe_rules.return_value = {"Rules": [{"RuleArn": "rule_arn"}]}
+        boto_mock.client().describe_tags.return_value = {
+            "TagDescriptions": [{"ResourceArn": "rule_arn", "Tags": []}]
+        }
+
+        maintenance_page = get_maintenance_page(boto_mock, "listener_arn")
+        assert maintenance_page is None
+
+    def test_when_environment_offline_with_default_page(self):
+        from dbt_copilot_helper.commands.environment import get_maintenance_page
+
+        boto_mock = MagicMock()
+        boto_mock.client().describe_rules.return_value = {"Rules": [{"RuleArn": "rule_arn"}]}
+        boto_mock.client().describe_tags.return_value = {
+            "TagDescriptions": [
+                {
+                    "ResourceArn": "rule_arn",
+                    "Tags": [
+                        {"Key": "name", "Value": "MaintenancePage"},
+                        {"Key": "type", "Value": "default"},
+                    ],
+                }
+            ]
+        }
+
+        maintenance_page = get_maintenance_page(boto_mock, "listener_arn")
+        assert maintenance_page == "default"
+
+
+class TestRemoveMaintenancePage:
+    def test_when_environment_online(self):
+        from dbt_copilot_helper.commands.environment import ListenerRuleNotFoundError
+        from dbt_copilot_helper.commands.environment import remove_maintenance_page
+
+        boto_mock = MagicMock()
+        boto_mock.client().describe_rules.return_value = {"Rules": [{"RuleArn": "rule_arn"}]}
+        boto_mock.client().describe_tags.return_value = {
+            "TagDescriptions": [{"ResourceArn": "rule_arn", "Tags": []}]
+        }
+
+        with pytest.raises(ListenerRuleNotFoundError):
+            remove_maintenance_page(boto_mock, "listener_arn")
+
+    def test_when_environment_offline(self):
+        from dbt_copilot_helper.commands.environment import remove_maintenance_page
+
+        boto_mock = MagicMock()
+        boto_mock.client().describe_rules.return_value = {"Rules": [{"RuleArn": "rule_arn"}]}
+        boto_mock.client().describe_tags.return_value = {
+            "TagDescriptions": [
+                {
+                    "ResourceArn": "rule_arn",
+                    "Tags": [
+                        {"Key": "name", "Value": "MaintenancePage"},
+                        {"Key": "type", "Value": "default"},
+                    ],
+                }
+            ]
+        }
+        boto_mock.client().delete_rule.return_value = None
+
+        remove_maintenance_page(boto_mock, "listener_arn")
+
+
+class TestAddMaintenancePage:
+    @pytest.mark.parametrize("template", ["default", "migration"])
+    @patch("dbt_copilot_helper.commands.environment.get_maintenance_page_template")
+    def test_adding_existing_template(self, get_maintenance_page_template, template):
+        from dbt_copilot_helper.commands.environment import add_maintenance_page
+
+        boto_mock = MagicMock()
+        get_maintenance_page_template.return_value = template
+
+        add_maintenance_page(boto_mock, "listener_arn", template)
+
+        boto_mock.client().create_rule.assert_called_with(
+            ListenerArn="listener_arn",
+            Priority=1,
+            Conditions=[
+                {
+                    "Field": "path-pattern",
+                    "PathPatternConfig": {"Values": ["/*"]},
+                }
+            ],
+            Actions=[
+                {
+                    "Type": "fixed-response",
+                    "FixedResponseConfig": {
+                        "StatusCode": "503",
+                        "ContentType": "text/html",
+                        "MessageBody": template,
+                    },
+                }
+            ],
+            Tags=[
+                {"Key": "name", "Value": "MaintenancePage"},
+                {"Key": "type", "Value": template},
+            ],
+        )
+
+
+class TestEnvironmentMaintenanceTemplates:
+    @pytest.mark.parametrize("template", ["default", "migration"])
+    def test_template_length(self, template):
+        from dbt_copilot_helper.commands.environment import (
+            get_maintenance_page_template,
+        )
+
+        contents = get_maintenance_page_template(template)
+        assert len(contents) <= 1024
+
+    @pytest.mark.parametrize("template", ["default", "migration"])
+    def test_template_no_new_lines(self, template):
+        from dbt_copilot_helper.commands.environment import (
+            get_maintenance_page_template,
+        )
+
+        contents = get_maintenance_page_template(template)
+        assert "\n" not in contents

--- a/tests/copilot_helper/test_copilot_helper.py
+++ b/tests/copilot_helper/test_copilot_helper.py
@@ -27,6 +27,7 @@ class TestCopilotHelperCli:
             "config",
             "copilot",
             "domain",
+            "environment",
             "pipeline",
             "svc",
             "waf",


### PR DESCRIPTION
Adds two commands:

`copilot-helper environment offline --app <app> --env <env> [--template (default|migration)]`

Take an environment offline by setting a fixed response at the load balancer.

`copilot-helper environment online --app <app> --env <env>`

Take an environment online by removing the currently set maintenance page.