### PR TITLE
move prod domain to live aws

### DIFF
--- a/dbt_copilot_helper/commands/dns.py
+++ b/dbt_copilot_helper/commands/dns.py
@@ -28,7 +28,7 @@ from dbt_copilot_helper.utils.versioning import (
 AVAILABLE_DOMAINS = {
     "great.gov.uk": "live",
     "trade.gov.uk": "live",
-    "prod.uktrade.digital": "dev",
+    "prod.uktrade.digital": "live",
     "uktrade.digital": "dev",
 }
 AWS_CERT_REGION = "eu-west-2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.113"
+version = "0.1.114"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/test_command_dns.py
+++ b/tests/copilot_helper/test_command_dns.py
@@ -434,7 +434,7 @@ def test_configure_success(
     [
         ("dev", "dev"),
         ("staging", "dev"),
-        ("prod1", "dev"),
+        ("prod1", "live"),
         ("prod2", "live"),
         ("prod3", "live"),
     ],


### PR DESCRIPTION
very quick PR to move the prod.uktrade.digital domain to live, as this is where the R53 domain is now.