### PR TITLE
DBTP-351 Temporarily restrict max paketobuildpacks/builder-jammy-base to 0.4.240

### DIFF
--- a/dbt_copilot_helper/commands/codebase.py
+++ b/dbt_copilot_helper/commands/codebase.py
@@ -59,6 +59,9 @@ def prepare():
         None,
     )
     builder_version = max(x["version"] for x in builder_versions["versions"])
+    # Temporary hack until https://uktrade.atlassian.net/browse/DBTP-351 is done
+    # Will need a change in tests/copilot_helper/expected_files/.copilot/config.yml, when removed.
+    builder_version = min(builder_version, "0.4.240")
 
     Path("./.copilot/phases").mkdir(parents=True, exist_ok=True)
     image_build_run_contents = templates.get_template(f".copilot/image_build_run.sh").render()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.115"
+version = "0.1.116"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/expected_files/.copilot/config.yml
+++ b/tests/copilot_helper/expected_files/.copilot/config.yml
@@ -1,7 +1,7 @@
 repository: test-app
 builder:
   name: paketobuildpacks/builder-jammy-base
-  version: 0.5.678
+  version: 0.4.240
 packages:
   - libpq-dev
   - libsqlite3-dev


### PR DESCRIPTION
To avoid time wasting confusion when people run `copilot-helper codebase prepare` and it uses the latest version of paketobuildpacks/builder-jammy-base, which is not compatible with the latest version of `fagiani/apt`.

```
ERROR: failed to build: validating buildpacks: buildpack 'fagiani/apt@0.2.5' (Buildpack API 0.4) is incompatible with lifecycle '0.18.2' (Buildpack API(s) 0.7, 0.8, 0.9, 0.10)
```

Will be addressed properly under https://uktrade.atlassian.net/browse/DBTP-351.