### PR TITLE
DBTP-448 Make conduit --addon-name required

### DIFF
--- a/dbt_copilot_helper/COMMANDS.md
+++ b/dbt_copilot_helper/COMMANDS.md
@@ -521,7 +521,7 @@ copilot-helper codebuild slackcreds --workspace <workspace> --channel <channel>
 
 ```
 copilot-helper conduit (opensearch|postgres|redis) 
-                       --app <app> --env <env> [--addon-name <addon_name>] 
+                       --app <app> --env <env> --addon-name <addon_name> 
 ```
 
 ## Arguments

--- a/dbt_copilot_helper/commands/conduit.py
+++ b/dbt_copilot_helper/commands/conduit.py
@@ -266,7 +266,7 @@ def start_conduit(app: str, env: str, addon_type: str, addon_name: str = None):
 
     application = load_application(app)
     cluster_arn = get_cluster_arn(application, env)
-    addon_name = addon_name or addon_type
+    addon_name = addon_name
     task_name = get_or_create_task_name(application, env, addon_name)
 
     if not addon_client_is_running(application, env, cluster_arn, task_name):
@@ -281,7 +281,7 @@ def start_conduit(app: str, env: str, addon_type: str, addon_name: str = None):
 @click.argument("addon_type", type=click.Choice(CONDUIT_ADDON_TYPES))
 @click.option("--app", help="AWS application name", required=True)
 @click.option("--env", help="AWS environment name", required=True)
-@click.option("--addon-name", help="Name of custom addon", required=False)
+@click.option("--addon-name", help="Name of custom addon", required=True)
 def conduit(addon_type: str, app: str, env: str, addon_name: str):
     """Create a conduit connection to an addon."""
     check_copilot_helper_version_needs_update()

--- a/dbt_copilot_helper/commands/conduit.py
+++ b/dbt_copilot_helper/commands/conduit.py
@@ -266,7 +266,6 @@ def start_conduit(app: str, env: str, addon_type: str, addon_name: str = None):
 
     application = load_application(app)
     cluster_arn = get_cluster_arn(application, env)
-    addon_name = addon_name
     task_name = get_or_create_task_name(application, env, addon_name)
 
     if not addon_client_is_running(application, env, cluster_arn, task_name):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.119"
+version = "0.1.120"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/test_command_conduit.py
+++ b/tests/copilot_helper/test_command_conduit.py
@@ -493,24 +493,25 @@ def test_start_conduit(
     add_stack_delete_policy_to_task_role and connect_to_addon_client_task."""
     from dbt_copilot_helper.commands.conduit import start_conduit
 
-    task_name = mock_task_name(addon_type)
+    addon_name = addon_type.upper()
+    task_name = mock_task_name(addon_name)
     get_or_create_task_name.side_effect = [task_name]
 
-    start_conduit("test-application", "development", addon_type, None)
+    start_conduit("test-application", "development", addon_type, addon_name)
 
     get_cluster_arn.assert_called_once_with(mock_application, "development")
-    get_or_create_task_name.assert_called_once_with(mock_application, "development", addon_type)
+    get_or_create_task_name.assert_called_once_with(mock_application, "development", addon_name)
     addon_client_is_running.assert_called_with(
         mock_application, "development", "test-arn", task_name
     )
     create_addon_client_task.assert_called_once_with(
-        mock_application, "development", addon_type, addon_type, task_name
+        mock_application, "development", addon_type, addon_name, task_name
     )
     add_stack_delete_policy_to_task_role.assert_called_once_with(
         mock_application, "development", task_name
     )
     update_conduit_stack_resources.assert_called_once_with(
-        mock_application, "development", addon_type, addon_type, task_name
+        mock_application, "development", addon_type, addon_name, task_name
     )
     connect_to_addon_client_task.assert_called_once_with(
         mock_application, "development", "test-arn", task_name
@@ -687,20 +688,21 @@ def test_start_conduit_when_no_secret_exists(
     from dbt_copilot_helper.commands.conduit import SecretNotFoundConduitError
     from dbt_copilot_helper.commands.conduit import start_conduit
 
+    addon_name = addon_type.upper()
     create_addon_client_task.side_effect = SecretNotFoundConduitError
-    task_name = mock_task_name(addon_type)
+    task_name = mock_task_name(addon_name)
     get_or_create_task_name.side_effect = [task_name]
 
     with pytest.raises(SecretNotFoundConduitError):
-        start_conduit("test-application", "development", addon_type)
+        start_conduit("test-application", "development", addon_type, addon_name)
 
     get_cluster_arn.assert_called_once_with(mock_application, "development")
-    get_or_create_task_name.assert_called_once_with(mock_application, "development", addon_type)
+    get_or_create_task_name.assert_called_once_with(mock_application, "development", addon_name)
     addon_client_is_running.assert_called_with(
         mock_application, "development", "test-arn", task_name
     )
     create_addon_client_task.assert_called_once_with(
-        mock_application, "development", addon_type, addon_type, task_name
+        mock_application, "development", addon_type, addon_name, task_name
     )
     add_stack_delete_policy_to_task_role.assert_not_called()
     update_conduit_stack_resources.assert_not_called()
@@ -789,26 +791,27 @@ def test_start_conduit_when_addon_client_task_fails_to_start(
     from dbt_copilot_helper.commands.conduit import CreateTaskTimeoutConduitError
     from dbt_copilot_helper.commands.conduit import start_conduit
 
+    addon_name = addon_type.upper()
     connect_to_addon_client_task.side_effect = CreateTaskTimeoutConduitError
-    task_name = mock_task_name(addon_type)
+    task_name = mock_task_name(addon_name)
     get_or_create_task_name.side_effect = [task_name]
 
     with pytest.raises(CreateTaskTimeoutConduitError):
-        start_conduit("test-application", "development", addon_type)
+        start_conduit("test-application", "development", addon_type, addon_name)
 
     get_cluster_arn.assert_called_once_with(mock_application, "development")
-    get_or_create_task_name.assert_called_once_with(mock_application, "development", addon_type)
+    get_or_create_task_name.assert_called_once_with(mock_application, "development", addon_name)
     addon_client_is_running.assert_called_with(
         mock_application, "development", "test-arn", task_name
     )
     create_addon_client_task.assert_called_once_with(
-        mock_application, "development", addon_type, addon_type, task_name
+        mock_application, "development", addon_type, addon_name, task_name
     )
     add_stack_delete_policy_to_task_role.assert_called_once_with(
         mock_application, "development", task_name
     )
     update_conduit_stack_resources.assert_called_once_with(
-        mock_application, "development", addon_type, addon_type, task_name
+        mock_application, "development", addon_type, addon_name, task_name
     )
     connect_to_addon_client_task.assert_called_once_with(
         mock_application, "development", "test-arn", task_name
@@ -844,13 +847,14 @@ def test_start_conduit_when_addon_client_task_is_already_running(
     called."""
     from dbt_copilot_helper.commands.conduit import start_conduit
 
-    task_name = mock_task_name(addon_type)
+    addon_name = addon_type.upper()
+    task_name = mock_task_name(addon_name)
     get_or_create_task_name.side_effect = [task_name]
 
-    start_conduit("test-application", "development", addon_type)
+    start_conduit("test-application", "development", addon_type, addon_name)
 
     get_cluster_arn.assert_called_once_with(mock_application, "development")
-    get_or_create_task_name.assert_called_once_with(mock_application, "development", addon_type)
+    get_or_create_task_name.assert_called_once_with(mock_application, "development", addon_name)
     addon_client_is_running.assert_called_once_with(
         mock_application, "development", "test-arn", task_name
     )
@@ -875,6 +879,8 @@ def test_conduit_command(start_conduit, addon_type, validate_version):
     calls start_conduit with app, env, addon type and no addon name."""
     from dbt_copilot_helper.commands.conduit import conduit
 
+    addon_name = addon_type.upper()
+
     CliRunner().invoke(
         conduit,
         [
@@ -883,11 +889,13 @@ def test_conduit_command(start_conduit, addon_type, validate_version):
             "test-application",
             "--env",
             "development",
+            "--addon-name",
+            addon_name,
         ],
     )
 
     validate_version.assert_called_once()
-    start_conduit.assert_called_once_with("test-application", "development", addon_type, None)
+    start_conduit.assert_called_once_with("test-application", "development", addon_type, addon_name)
 
 
 @pytest.mark.parametrize(
@@ -949,6 +957,8 @@ def test_conduit_command_when_no_cluster_exists(start_conduit, secho, addon_type
             "test-application",
             "--env",
             "development",
+            "--addon-name",
+            addon_type.upper(),
         ],
     )
 
@@ -978,6 +988,7 @@ def test_conduit_command_when_no_connection_secret_exists(
     from dbt_copilot_helper.commands.conduit import conduit
 
     start_conduit.side_effect = SecretNotFoundConduitError(addon_type)
+    addon_name = addon_type.upper()
 
     result = CliRunner().invoke(
         conduit,
@@ -987,13 +998,15 @@ def test_conduit_command_when_no_connection_secret_exists(
             "test-application",
             "--env",
             "development",
+            "--addon-name",
+            addon_name,
         ],
     )
 
     assert result.exit_code == 1
     validate_version.assert_called_once()
     secho.assert_called_once_with(
-        f"""No secret called "{addon_type}" for "test-application" in "development" environment.""",
+        f"""No secret called "{addon_name}" for "test-application" in "development" environment.""",
         fg="red",
     )
 
@@ -1068,6 +1081,8 @@ def test_conduit_command_when_client_task_fails_to_start(
             "test-application",
             "--env",
             "development",
+            "--addon-name",
+            addon_type.upper(),
         ],
     )
 


### PR DESCRIPTION
To reduce confusion and rabbit holing until https://uktrade.atlassian.net/browse/DBTP-448 is actioned.