### PR TITLE
DBTP-648 must specify `--env` when migrating secrets

### DIFF
--- a/dbt_copilot_helper/COMMANDS.md
+++ b/dbt_copilot_helper/COMMANDS.md
@@ -127,7 +127,7 @@ copilot-helper bootstrap make-config [-d <directory>]
 
 ```
 copilot-helper bootstrap migrate-secrets --project-profile <project_profile> 
-                                         [--env <env>] [--svc <svc>] 
+                                         --env <env> [--svc <svc>] 
                                          [--overwrite] [--dry-run] 
 ```
 

--- a/dbt_copilot_helper/commands/bootstrap.py
+++ b/dbt_copilot_helper/commands/bootstrap.py
@@ -191,7 +191,7 @@ def migrate_secrets(project_profile, env, svc, overwrite, dry_run):
             click.echo(f"getting env vars for from {environment['paas']}")
             env_vars = get_paas_env_vars(cf_client, environment["paas"])
 
-            click.echo("Transfering secrets ...")
+            click.echo("Transferring secrets ...")
             for app_secret_key, ssm_secret_key in secrets.items():
                 if secret_should_be_skipped(app_secret_key):
                     continue
@@ -208,7 +208,8 @@ def migrate_secrets(project_profile, env, svc, overwrite, dry_run):
                     # FOUND BUT EMPTY STRING
                     param_value = "EMPTY"
                     click.echo(
-                        f"Empty env var in paas app: {app_secret_key}; SSM requires a non-empty string; setting to 'EMPTY'",
+                        f"Empty env var in paas app: {app_secret_key}; "
+                        f"SSM requires a non-empty string; setting to 'EMPTY'",
                     )
                 else:
                     param_value = env_vars[app_secret_key]

--- a/dbt_copilot_helper/commands/bootstrap.py
+++ b/dbt_copilot_helper/commands/bootstrap.py
@@ -125,7 +125,7 @@ def make_config(directory="."):
 
 @bootstrap.command()
 @click.option("--project-profile", required=True, help="AWS account profile name")
-@click.option("--env", help="Migrate secrets from a specific environment")
+@click.option("--env", required=True, help="Migrate secrets from a specific environment")
 @click.option("--svc", help="Migrate secrets from a specific service")
 @click.option(
     "--overwrite",
@@ -154,7 +154,7 @@ def migrate_secrets(project_profile, env, svc, overwrite, dry_run):
     config_file = "bootstrap.yml"
     config = load_and_validate_config(config_file, BOOTSTRAP_SCHEMA)
 
-    if env and env not in config["environments"].keys():
+    if env not in config["environments"].keys():
         raise click.ClickException(f"{env} is not an environment in {config_file}")
 
     if svc and svc not in [service["name"] for service in config["services"]]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.121"
+version = "0.1.122"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"


### PR DESCRIPTION
No tests removed as none exist for running the command without `--env` set.