### PR TITLE
Use tag-latest rather than latest as the default tag

### DIFF
--- a/dbt_copilot_helper/COMMANDS.md
+++ b/dbt_copilot_helper/COMMANDS.md
@@ -854,7 +854,7 @@ copilot-helper svc deploy --env <env> --name <name> [--image-tag <image_tag>]
 
 - `--name <text>`
 
-- `--image-tag <text>` _Defaults to latest._
+- `--image-tag <text>` _Defaults to tag-latest._
 
 - `--help <boolean>` _Defaults to False._
   - Show this message and exit.

--- a/dbt_copilot_helper/commands/svc.py
+++ b/dbt_copilot_helper/commands/svc.py
@@ -29,11 +29,9 @@ def deploy(env, name, image_tag):
     """Deploy image tag to a service, defaults to image tagged latest."""
 
     if image_tag == "latest":
-        click.secho(
-            f'Releasing tag "latest" is not supported. Use tag "tag-latest" instead.',
-            fg="red",
+        abort_with_message(
+            f'Releasing tag "latest" is not supported. Use tag "tag-latest" instead.'
         )
-        exit(1)
 
     deploy_command = f"copilot svc deploy --env {env} --name {name}"
 
@@ -45,11 +43,7 @@ def deploy(env, name, image_tag):
         if image_tag == "tag-latest":
             image_tag = get_commit_tag_for_image(image_tags)
             if not image_tag:
-                click.secho(
-                    'The image tagged "tag-latest" does not have a commit tag.',
-                    fg="red",
-                )
-                exit(1)
+                abort_with_message('The image tagged "tag-latest" does not have a commit tag.')
 
         deploy_command = f"IMAGE_TAG={image_tag} {deploy_command}"
 
@@ -58,6 +52,14 @@ def deploy(env, name, image_tag):
         deploy_command,
         shell=True,
     )
+
+
+def abort_with_message(message):
+    click.secho(
+        message,
+        fg="red",
+    )
+    exit(1)
 
 
 def get_all_tags_for_image(image_tag_needle, repository_name):
@@ -91,15 +93,12 @@ def validate_service_manifest_and_return_repository(name):
     try:
         service_name_in_manifest = get_service_name_from_manifest(service_manifest)
         if service_name_in_manifest != name:
-            click.secho(
-                f"Service manifest for {name} has name attribute {service_name_in_manifest}",
-                fg="red",
+            abort_with_message(
+                f"Service manifest for {name} has name attribute {service_name_in_manifest}"
             )
-            exit(1)
     except FileNotFoundError:
-        click.secho(
-            f"Service manifest for {name} could not be found at path {service_manifest}", fg="red"
+        abort_with_message(
+            f"Service manifest for {name} could not be found at path {service_manifest}"
         )
-        exit(1)
 
     return get_repository_name_from_manifest(service_manifest)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.122"
+version = "0.1.123"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"


### PR DESCRIPTION
Changed behaviour to reject latest tag and to default to the tag-latest tag.

Reject the tag-latest tag if there is no corresponding commit- tag