### PR TITLE
DBTP-660 Add OpenTelemetry variables to manifest files

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,36 @@
+FROM debian:stable-slim
+
+ARG PYTHON_VERSIONS="3.9 3.10 3.11"
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV PYENV_ROOT="$HOME/.pyenv"
+ENV PATH="$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    curl \
+    git \
+    libbz2-dev \
+    libffi-dev \
+    liblzma-dev \
+    libncurses5-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    llvm \
+    make \
+    tk-dev \
+    wget \
+    xz-utils \
+    zlib1g-dev \
+  && apt-get clean autoclean \
+  && apt-get autoremove -y \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -f /var/cache/apt/archives/*.deb \
+  && git clone https://github.com/pyenv/pyenv .pyenv \
+  && pyenv install ${PYTHON_VERSIONS} \
+  && pyenv global $(echo ${PYTHON_VERSIONS} | awk '{ print $NF }')

--- a/dbt_copilot_helper/templates/svc/manifest-backend.yml
+++ b/dbt_copilot_helper/templates/svc/manifest-backend.yml
@@ -36,6 +36,8 @@ variables:                    # Pass environment variables as key value pairs.
   OTEL_SERVICE_NAME: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-{{ name }}
   OTEL_METRICS_EXPORTER: console,otlp
   OTEL_TRACES_EXPORTER: console,otlp
+  OTEL_TRACES_SAMPLER: traceidratio
+  OTEL_TRACES_SAMPLER_ARG: "0.05"
   {%- for envvar, value in env_vars %}
   {{ envvar }}:
   {% endfor %}

--- a/dbt_copilot_helper/templates/svc/manifest-backend.yml
+++ b/dbt_copilot_helper/templates/svc/manifest-backend.yml
@@ -26,8 +26,16 @@ exec: true     # Enable running commands in your container.
 storage:
   readonly_fs: true       # Limit to read-only access to mounted root filesystems.
 
+observability:
+  tracing: awsxray
+
 variables:                    # Pass environment variables as key value pairs.
   PORT: 8080                  # The bootstrap container requires a $PORT env var
+  OTEL_PROPAGATORS: xray
+  OTEL_PYTHON_ID_GENERATOR: xray
+  OTEL_SERVICE_NAME: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-{{ name }}
+  OTEL_METRICS_EXPORTER: console,otlp
+  OTEL_TRACES_EXPORTER: console,otlp
   {%- for envvar, value in env_vars %}
   {{ envvar }}:
   {% endfor %}

--- a/dbt_copilot_helper/templates/svc/manifest-public.yml
+++ b/dbt_copilot_helper/templates/svc/manifest-public.yml
@@ -85,6 +85,8 @@ variables:                    # Pass environment variables as key value pairs.
   OTEL_SERVICE_NAME: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-{{ name }}
   OTEL_METRICS_EXPORTER: console,otlp
   OTEL_TRACES_EXPORTER: console,otlp
+  OTEL_TRACES_SAMPLER: traceidratio
+  OTEL_TRACES_SAMPLER_ARG: "0.05"
 {%- for envvar, value in env_vars.items() %}
   {{ envvar }}:
 {%- endfor %}

--- a/dbt_copilot_helper/templates/svc/manifest-public.yml
+++ b/dbt_copilot_helper/templates/svc/manifest-public.yml
@@ -73,10 +73,18 @@ network:
 storage:
   readonly_fs: true       # Limit to read-only access to mounted root filesystems.
 
+observability:
+  tracing: awsxray
+
 # Optional fields for more advanced use-cases.
 #
 variables:                    # Pass environment variables as key value pairs.
   PORT: 8080
+  OTEL_PROPAGATORS: xray
+  OTEL_PYTHON_ID_GENERATOR: xray
+  OTEL_SERVICE_NAME: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-{{ name }}
+  OTEL_METRICS_EXPORTER: console,otlp
+  OTEL_TRACES_EXPORTER: console,otlp
 {%- for envvar, value in env_vars.items() %}
   {{ envvar }}:
 {%- endfor %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.126"
+version = "0.1.127"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.125"
+version = "0.1.126"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/fixtures/test_service_manifest.yml
+++ b/tests/copilot_helper/fixtures/test_service_manifest.yml
@@ -73,10 +73,18 @@ network:
 storage:
   readonly_fs: true       # Limit to read-only access to mounted root filesystems.
 
+observability:
+  tracing: awsxray
+
 # Optional fields for more advanced use-cases.
 #
 variables:                    # Pass environment variables as key value pairs.
   PORT: 8080
+  OTEL_PROPAGATORS: xray
+  OTEL_PYTHON_ID_GENERATOR: xray
+  OTEL_SERVICE_NAME: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-test-service
+  OTEL_METRICS_EXPORTER: console,otlp
+  OTEL_TRACES_EXPORTER: console,otlp
   TEST_VAR:
 
 

--- a/tests/copilot_helper/fixtures/test_service_manifest.yml
+++ b/tests/copilot_helper/fixtures/test_service_manifest.yml
@@ -85,6 +85,8 @@ variables:                    # Pass environment variables as key value pairs.
   OTEL_SERVICE_NAME: ${COPILOT_APPLICATION_NAME}-${COPILOT_ENVIRONMENT_NAME}-test-service
   OTEL_METRICS_EXPORTER: console,otlp
   OTEL_TRACES_EXPORTER: console,otlp
+  OTEL_TRACES_SAMPLER: traceidratio
+  OTEL_TRACES_SAMPLER_ARG: "0.05"
   TEST_VAR:
 
 


### PR DESCRIPTION
## Context

- Add OTel env vars to manifest template files
  - This is to setup observability (X-Ray) for services.
  - The sampling ratio is set at a default of 5%.
- Add `Dockerfile.debian` file
  - This is currently used for `copilot-python` as the Alpine Dockerfile does not support installing gRPC within a `poetry` context. This image should also be used for this repo in the near future to avoid issues like this from reoccurring.