### PR TITLE
DBTP-675 make-addons generates addons and overrides for scheduled jobs

### DIFF
--- a/dbt_copilot_helper/commands/copilot.py
+++ b/dbt_copilot_helper/commands/copilot.py
@@ -44,8 +44,11 @@ def list_copilot_local_environments():
 def is_service(path: PosixPath) -> bool:
     with open(path) as manifest_file:
         data = yaml.safe_load(manifest_file)
-        if not data:
-            return False
+        if not data or not data.get("type"):
+            click.echo(
+                click.style(f"No type defined in manifest file {str(path)}; exiting", fg="red")
+            )
+            exit(1)
 
         return data.get("type") in SERVICE_TYPES
 

--- a/dbt_copilot_helper/commands/copilot.py
+++ b/dbt_copilot_helper/commands/copilot.py
@@ -5,6 +5,7 @@ import json
 from os import listdir
 from os.path import isfile
 from pathlib import Path
+from pathlib import PosixPath
 
 import boto3
 import click
@@ -25,6 +26,14 @@ PACKAGE_DIR = Path(__file__).resolve().parent.parent
 
 WAF_ACL_ARN_KEY = "waf-acl-arn"
 
+SERVICE_TYPES = [
+    "Load Balanced Web Service",
+    "Backend Service",
+    "Request-Driven Web Service",
+    "Static Site",
+    "Worker Service",
+]
+
 
 def list_copilot_local_environments():
     return [
@@ -32,8 +41,21 @@ def list_copilot_local_environments():
     ]
 
 
+def is_service(path: PosixPath) -> bool:
+    with open(path) as manifest_file:
+        data = yaml.safe_load(manifest_file)
+        if not data:
+            return False
+
+        return data.get("type") in SERVICE_TYPES
+
+
 def list_copilot_local_services():
-    return [path.parent.parts[-1] for path in Path("./copilot/").glob("*/manifest.yml")]
+    return [
+        path.parent.parts[-1]
+        for path in Path("./copilot/").glob("*/manifest.yml")
+        if is_service(path)
+    ]
 
 
 @click.group(chain=True, cls=ClickDocOptGroup)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.125"
+version = "0.1.126"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/test_command_copilot.py
+++ b/tests/copilot_helper/test_command_copilot.py
@@ -518,7 +518,10 @@ invalid-entry:
     def test_exit_if_no_local_copilot_environments(self, fakefs):
         fakefs.create_file(ADDON_CONFIG_FILENAME)
 
-        fakefs.create_file("copilot/web/manifest.yml")
+        fakefs.create_file(
+            "copilot/web/manifest.yml",
+            contents=" ".join([yaml.dump(yaml.safe_load(WEB_SERVICE_CONTENTS))]),
+        )
 
         result = CliRunner().invoke(copilot, ["make-addons"])
 
@@ -743,3 +746,14 @@ def test_is_service(fakefs, service_type, expected):
     )
 
     assert is_service(PosixPath("copilot/web/manifest.yml")) == expected
+
+
+def test_is_service_empty_manifest(fakefs, capfd):
+    file_path = "copilot/web/manifest.yml"
+    fakefs.create_file(file_path)
+
+    with pytest.raises(SystemExit) as excinfo:
+        is_service(PosixPath(file_path))
+
+    assert excinfo.value.code == 1
+    assert f"No type defined in manifest file {file_path}; exiting" in capfd.readouterr().out


### PR DESCRIPTION
Add an `is_service` check to `list_copilot_local_services`, so that `make-addons` can distinguish between services and scheduled jobs.