### PR TITLE
DBTP-672 - Domain configure error creating certificate

### DIFF
--- a/dbt_copilot_helper/commands/dns.py
+++ b/dbt_copilot_helper/commands/dns.py
@@ -121,30 +121,28 @@ def _create_resource_records(cert_record, domain_client, zone_id):
         "ResourceRecordSets"
     ]
 
-    exists = False
     for record in resource_records:
         if record["Type"] == cert_record["Type"] and record["Name"] == cert_record["Name"]:
-            exists = True
+            return
 
-    if not exists:
-        domain_client.change_resource_record_sets(
-            HostedZoneId=zone_id,
-            ChangeBatch={
-                "Changes": [
-                    {
-                        "Action": "CREATE",
-                        "ResourceRecordSet": {
-                            "Name": cert_record["Name"],
-                            "Type": cert_record["Type"],
-                            "TTL": 300,
-                            "ResourceRecords": [
-                                {"Value": cert_record["Value"]},
-                            ],
-                        },
+    domain_client.change_resource_record_sets(
+        HostedZoneId=zone_id,
+        ChangeBatch={
+            "Changes": [
+                {
+                    "Action": "CREATE",
+                    "ResourceRecordSet": {
+                        "Name": cert_record["Name"],
+                        "Type": cert_record["Type"],
+                        "TTL": 300,
+                        "ResourceRecords": [
+                            {"Value": cert_record["Value"]},
+                        ],
                     },
-                ],
-            },
-        )
+                },
+            ],
+        },
+    )
 
 
 def _certs_for_domain(client, domain):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.127"
+version = "0.1.128"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/test_command_dns.py
+++ b/tests/copilot_helper/test_command_dns.py
@@ -237,8 +237,6 @@ def test_create_cert_deletes_the_old_and_creates_a_new_cert_if_existing_one_is_p
 def test_create_cert_with_existing_record_sets_creates_a_cert(
     _wait_for_certificate_validation, mock_click, acm_session, route53_session
 ):
-    cert_name = "_d930b28be6c5927595552b219965053e.test.1234."
-
     resp = route53_session.create_hosted_zone(Name="1234", CallerReference="1234")
     zone_id = resp["HostedZone"]["Id"]
 
@@ -249,7 +247,7 @@ def test_create_cert_with_existing_record_sets_creates_a_cert(
                 {
                     "Action": "CREATE",
                     "ResourceRecordSet": {
-                        "Name": cert_name,
+                        "Name": "_d930b28be6c5927595552b219965053e.test.1234.",
                         "Type": "CNAME",
                         "TTL": 300,
                         "ResourceRecords": [


### PR DESCRIPTION
- Add test for creating a certificate when a record already exists
- Fix error in `domain configure` command when re-creating a certificate and a record already exists