### PR TITLE
Update PyPI buildspec for `debian` image

### DIFF
--- a/buildspec.pypi.yml
+++ b/buildspec.pypi.yml
@@ -9,7 +9,7 @@ phases:
   install:
     commands:
       - echo Setting local Python versions
-      - pyenv versions | awk 'match($0, /\d\.\d+\.\d+/) { print substr($0, RSTART, RLENGTH) }' | sort -rV > .python-version
+      - pyenv versions | awk 'match($0, /[0-9]\.[0-9]+\.[0-9]+/) { print substr($0, RSTART, RLENGTH) }' > .python-version
       - echo Installing dependencies
       - pip install poetry
       - poetry install


### PR DESCRIPTION
## Context

- Update the RegEx to work with the `debian` image.
  - Reference: https://github.com/uktrade/copilot-tools/blob/a23607324d8eb7e7118150b6edd67c2640a8b4ba/buildspec.test.yml#L7