### PR TITLE
Add some Python version checking to some build pipelines

### DIFF
--- a/buildspec.pypi.yml
+++ b/buildspec.pypi.yml
@@ -10,6 +10,8 @@ phases:
     commands:
       - echo Setting local Python versions
       - pyenv versions | awk 'match($0, /[0-9]\.[0-9]+\.[0-9]+/) { print substr($0, RSTART, RLENGTH) }' > .python-version
+      - echo Checking Python version
+      - python --version
       - echo Installing dependencies
       - pip install poetry
       - poetry install
@@ -22,6 +24,8 @@ phases:
         VERSION=$(python utils/check_pypi.py --version)
         if ! python utils/check_pypi.py
         then
+          echo Checking Python version
+          python --version
           echo Building Python package
           poetry build
           echo Publishing Python package ${VERSION}

--- a/buildspec.test.yml
+++ b/buildspec.test.yml
@@ -5,11 +5,15 @@ phases:
     commands:
       - echo Setting local Python versions
       - pyenv versions | awk 'match($0, /[0-9]\.[0-9]+\.[0-9]+/) { print substr($0, RSTART, RLENGTH) }' > .python-version
+      - echo Checking Python version
+      - python --version
       - echo Installing dependencies
       - pip install poetry
       - poetry install
 
   build:
     commands:
+      - echo Checking Python version
+      - python --version
       - echo Running tests
       - poetry run tox


### PR DESCRIPTION
To verify the version of Python being used, especially during the publish stage where we are seeing `ModuleNotFoundError: No module named 'tomllib'`,