### PR TITLE
Reverse the order in .python-version so latest is used by default

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -34,3 +34,5 @@ RUN apt-get update \
   && git clone https://github.com/pyenv/pyenv .pyenv \
   && pyenv install ${PYTHON_VERSIONS} \
   && pyenv global $(echo ${PYTHON_VERSIONS} | awk '{ print $NF }')
+
+COPY . /codebuild

--- a/buildspec.pypi.yml
+++ b/buildspec.pypi.yml
@@ -8,12 +8,11 @@ env:
 phases:
   install:
     commands:
-      - |
-        echo Ensure we are using the latest installed Python 3.x
-        pyenv global 3
-        python --version
       - echo Setting local Python versions
-      - pyenv versions | awk 'match($0, /[0-9]\.[0-9]+\.[0-9]+/) { print substr($0, RSTART, RLENGTH) }' > .python-version
+      - pyenv versions | awk 'match($0, /[0-9]\.[0-9]+\.[0-9]+/) { print substr($0, RSTART, RLENGTH) }' | tac > .python-version
+      - |
+        echo Check we are using the latest installed Python 3.x
+        python --version
       - echo Installing dependencies
       - pip install poetry
       - poetry install

--- a/buildspec.test.yml
+++ b/buildspec.test.yml
@@ -3,12 +3,11 @@ version: 0.2
 phases:
   install:
     commands:
-      - |
-        echo Ensure we are using the latest installed Python 3.x
-        pyenv global 3
-        python --version
       - echo Setting local Python versions
-      - pyenv versions | awk 'match($0, /[0-9]\.[0-9]+\.[0-9]+/) { print substr($0, RSTART, RLENGTH) }' > .python-version
+      - pyenv versions | awk 'match($0, /[0-9]\.[0-9]+\.[0-9]+/) { print substr($0, RSTART, RLENGTH) }' | tac > .python-version
+      - |
+        echo Check we are using the latest installed Python 3.x
+        python --version
       - echo Installing dependencies
       - pip install poetry
       - poetry install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.132"
+version = "0.1.133"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"


### PR DESCRIPTION
After playing around with it locally, it seems that `pyenv` uses the first version in `.python-version` by default.