### PR TITLE
Better `copilot-helper bootstrap migrate-secrets` cloudfoundry errors

### DIFF
--- a/dbt_copilot_helper/commands/bootstrap.py
+++ b/dbt_copilot_helper/commands/bootstrap.py
@@ -14,6 +14,7 @@ from dbt_copilot_helper.utils.aws import get_ssm_secret_names
 from dbt_copilot_helper.utils.aws import get_ssm_secrets
 from dbt_copilot_helper.utils.aws import set_ssm_param
 from dbt_copilot_helper.utils.click import ClickDocOptGroup
+from dbt_copilot_helper.utils.cloudfoundry import get_cloud_foundry_client_or_abort
 from dbt_copilot_helper.utils.files import load_and_validate_config
 from dbt_copilot_helper.utils.files import mkfile
 from dbt_copilot_helper.utils.files import to_yaml
@@ -141,7 +142,7 @@ def migrate_secrets(project_profile, env, svc, overwrite, dry_run):
     get_aws_session_or_abort(project_profile)
     # TODO: optional SSM or secret manager
 
-    cf_client = CloudFoundryClient.build_from_cf_config()
+    cf_client = get_cloud_foundry_client_or_abort()
     config_file = "bootstrap.yml"
     config = load_and_validate_config(config_file, BOOTSTRAP_SCHEMA)
 

--- a/dbt_copilot_helper/utils/cloudfoundry.py
+++ b/dbt_copilot_helper/utils/cloudfoundry.py
@@ -1,0 +1,14 @@
+import click
+from cloudfoundry_client.client import CloudFoundryClient
+
+
+def get_cloud_foundry_client_or_abort():
+    try:
+        client = CloudFoundryClient.build_from_cf_config()
+        click.secho("Logged in to Cloud Foundry", fg="green")
+        return client
+    except Exception as ex:
+        click.secho("Could not connect to Cloud Foundry: ", fg="red", nl=False)
+        click.secho(str(ex))
+        click.secho("Please log in with: cf login", fg="yellow")
+        exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "0.1.138"
+version = "0.1.139"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/test_command_bootstrap.py
+++ b/tests/copilot_helper/test_command_bootstrap.py
@@ -132,7 +132,7 @@ def test_make_config(tmp_path):
 
 
 @mock_sts
-@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient", return_value=MagicMock)
+@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient")
 def test_migrate_secrets_login_failure(mock_client, alias_session, aws_credentials, tmp_path):
     """Test that when login fails, a helpful message is printed and the command
     aborts."""
@@ -154,7 +154,7 @@ def test_migrate_secrets_login_failure(mock_client, alias_session, aws_credentia
 
 
 @mock_sts
-@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient", return_value=MagicMock)
+@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient")
 def test_migrate_secrets_env_not_in_config(client, alias_session, aws_credentials, tmp_path):
     """Test that, given a config file path and an environment not found in that
     file, migrate_secrets outputs the expected error message."""
@@ -170,7 +170,7 @@ def test_migrate_secrets_env_not_in_config(client, alias_session, aws_credential
 
 
 @mock_sts
-@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient", return_value=MagicMock)
+@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient")
 def test_migrate_secrets_service_not_in_config(client, alias_session, aws_credentials, tmp_path):
     """Test that, given a config file path and a secret not found in that file,
     migrate_secrets outputs the expected error message."""
@@ -196,7 +196,7 @@ def test_migrate_secrets_service_not_in_config(client, alias_session, aws_creden
 @mock_ssm
 @mock_sts
 @patch("dbt_copilot_helper.commands.bootstrap.get_paas_env_vars")
-@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient", return_value=MagicMock)
+@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient")
 def test_migrate_secrets_param_doesnt_exist(
     client,
     get_paas_env_vars,
@@ -228,7 +228,7 @@ def test_migrate_secrets_param_doesnt_exist(
 @mock_ssm
 @mock_sts
 @patch("dbt_copilot_helper.commands.bootstrap.get_paas_env_vars", return_value={})
-@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient", return_value=MagicMock)
+@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient")
 def test_migrate_secrets_param_already_exists(
     client, get_paas_env_vars, alias_session, aws_credentials, tmp_path
 ):
@@ -260,7 +260,7 @@ def test_migrate_secrets_param_already_exists(
 @mock_ssm
 @mock_sts
 @patch("dbt_copilot_helper.commands.bootstrap.get_paas_env_vars", return_value={})
-@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient", return_value=MagicMock)
+@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient")
 def test_migrate_secrets_overwrite(
     client, get_paas_env_vars, alias_session, aws_credentials, tmp_path
 ):
@@ -301,7 +301,7 @@ def test_migrate_secrets_overwrite(
 @mock_ssm
 @mock_sts
 @patch("dbt_copilot_helper.commands.bootstrap.get_paas_env_vars", return_value={})
-@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient", return_value=MagicMock)
+@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient")
 def test_migrate_secrets_dry_run(
     client, get_paas_env_vars, alias_session, aws_credentials, tmp_path
 ):
@@ -329,7 +329,7 @@ def test_migrate_secrets_dry_run(
 @mock_ssm
 @mock_sts
 @patch("dbt_copilot_helper.commands.bootstrap.get_paas_env_vars")
-@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient", return_value=MagicMock)
+@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient")
 def test_migrate_secrets_skips_aws_secrets(
     client,
     get_paas_env_vars_mock,

--- a/tests/copilot_helper/test_command_bootstrap.py
+++ b/tests/copilot_helper/test_command_bootstrap.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from http import HTTPStatus
 from pathlib import Path
 from unittest.mock import MagicMock
 from unittest.mock import Mock
@@ -13,6 +14,7 @@ from cloudfoundry_client.common_objects import JsonObject
 from freezegun import freeze_time
 from moto import mock_ssm
 from moto import mock_sts
+from oauth2_client.credentials_manager import OAuthError
 from schema import SchemaError
 
 from dbt_copilot_helper.commands.bootstrap import copy_secrets
@@ -38,10 +40,10 @@ class MockEntity(JsonObject):
         return [app]
 
 
-@patch("dbt_copilot_helper.commands.bootstrap.CloudFoundryClient", return_value=MagicMock)
-def test_get_pass_env_vars(client):
+def test_get_pass_env_vars():
     """Test that, given a CloudFoundryClient instance and an app's path string,
     get_paas_env_vars returns a dict of environment variables."""
+    client = Mock()
 
     org = MockEntity(entity={"name": "dit-staging"})
     client.v2.organizations = [org]
@@ -130,7 +132,29 @@ def test_make_config(tmp_path):
 
 
 @mock_sts
-@patch("dbt_copilot_helper.commands.bootstrap.CloudFoundryClient", return_value=MagicMock)
+@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient", return_value=MagicMock)
+def test_migrate_secrets_login_failure(mock_client, alias_session, aws_credentials, tmp_path):
+    """Test that when login fails, a helpful message is printed and the command
+    aborts."""
+    exception = OAuthError(
+        HTTPStatus(401),
+        "invalid_token",
+        "Invalid refresh token expired at Wed Aug 30 06:00:43 UTC 2023",
+    )
+    mock_client.build_from_cf_config.side_effect = exception
+
+    result = CliRunner().invoke(
+        migrate_secrets,
+        ["--project-profile", "foo", "--env", "staging", "--svc", "test-service"],
+    )
+
+    assert result.exit_code == 1
+    assert f"Could not connect to Cloud Foundry: {str(exception)}" in result.output
+    assert "Please log in with: cf login" in result.output
+
+
+@mock_sts
+@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient", return_value=MagicMock)
 def test_migrate_secrets_env_not_in_config(client, alias_session, aws_credentials, tmp_path):
     """Test that, given a config file path and an environment not found in that
     file, migrate_secrets outputs the expected error message."""
@@ -146,7 +170,7 @@ def test_migrate_secrets_env_not_in_config(client, alias_session, aws_credential
 
 
 @mock_sts
-@patch("dbt_copilot_helper.commands.bootstrap.CloudFoundryClient", return_value=MagicMock)
+@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient", return_value=MagicMock)
 def test_migrate_secrets_service_not_in_config(client, alias_session, aws_credentials, tmp_path):
     """Test that, given a config file path and a secret not found in that file,
     migrate_secrets outputs the expected error message."""
@@ -172,7 +196,7 @@ def test_migrate_secrets_service_not_in_config(client, alias_session, aws_creden
 @mock_ssm
 @mock_sts
 @patch("dbt_copilot_helper.commands.bootstrap.get_paas_env_vars")
-@patch("dbt_copilot_helper.commands.bootstrap.CloudFoundryClient", return_value=MagicMock)
+@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient", return_value=MagicMock)
 def test_migrate_secrets_param_doesnt_exist(
     client,
     get_paas_env_vars,
@@ -204,7 +228,7 @@ def test_migrate_secrets_param_doesnt_exist(
 @mock_ssm
 @mock_sts
 @patch("dbt_copilot_helper.commands.bootstrap.get_paas_env_vars", return_value={})
-@patch("dbt_copilot_helper.commands.bootstrap.CloudFoundryClient", return_value=MagicMock)
+@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient", return_value=MagicMock)
 def test_migrate_secrets_param_already_exists(
     client, get_paas_env_vars, alias_session, aws_credentials, tmp_path
 ):
@@ -236,7 +260,7 @@ def test_migrate_secrets_param_already_exists(
 @mock_ssm
 @mock_sts
 @patch("dbt_copilot_helper.commands.bootstrap.get_paas_env_vars", return_value={})
-@patch("dbt_copilot_helper.commands.bootstrap.CloudFoundryClient", return_value=MagicMock)
+@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient", return_value=MagicMock)
 def test_migrate_secrets_overwrite(
     client, get_paas_env_vars, alias_session, aws_credentials, tmp_path
 ):
@@ -277,7 +301,7 @@ def test_migrate_secrets_overwrite(
 @mock_ssm
 @mock_sts
 @patch("dbt_copilot_helper.commands.bootstrap.get_paas_env_vars", return_value={})
-@patch("dbt_copilot_helper.commands.bootstrap.CloudFoundryClient", return_value=MagicMock)
+@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient", return_value=MagicMock)
 def test_migrate_secrets_dry_run(
     client, get_paas_env_vars, alias_session, aws_credentials, tmp_path
 ):
@@ -305,7 +329,7 @@ def test_migrate_secrets_dry_run(
 @mock_ssm
 @mock_sts
 @patch("dbt_copilot_helper.commands.bootstrap.get_paas_env_vars")
-@patch("dbt_copilot_helper.commands.bootstrap.CloudFoundryClient", return_value=MagicMock)
+@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient", return_value=MagicMock)
 def test_migrate_secrets_skips_aws_secrets(
     client,
     get_paas_env_vars_mock,

--- a/tests/copilot_helper/utils/test_cloudfoundry.py
+++ b/tests/copilot_helper/utils/test_cloudfoundry.py
@@ -1,0 +1,38 @@
+from http import HTTPStatus
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+from oauth2_client.credentials_manager import OAuthError
+
+from dbt_copilot_helper.utils.cloudfoundry import get_cloud_foundry_client_or_abort
+
+
+@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient")
+def test_get_cloud_foundry_client_or_abort_success(mock_cf, capsys):
+    mock_client = Mock()
+    mock_cf.build_from_cf_config.return_value = mock_client
+
+    client = get_cloud_foundry_client_or_abort()
+
+    stdout = capsys.readouterr().out
+    assert "Logged in to Cloud Foundry" in stdout
+    assert client == mock_client
+
+
+@patch("dbt_copilot_helper.utils.cloudfoundry.CloudFoundryClient")
+def test_get_cloud_foundry_client_or_abort_prints_useful_message_and_exits(mock_cf, capsys):
+    exception = OAuthError(
+        HTTPStatus(401),
+        "invalid_token",
+        "Invalid refresh token expired at Wed Aug 30 06:00:43 UTC 2023",
+    )
+    mock_cf.build_from_cf_config.side_effect = exception
+
+    with pytest.raises(SystemExit) as ex:
+        get_cloud_foundry_client_or_abort()
+
+    stdout = capsys.readouterr().out
+    assert ex.value.code == 1
+    assert f"Could not connect to Cloud Foundry: {str(exception)}" in stdout
+    assert "Please log in with: cf login" in stdout


### PR DESCRIPTION
Previously a stack trace was displayed on the screen if you were not logged into Cloud Foundry before running this command. This PR makes the error message more useful and less noisy.