### PR TITLE
fix: all addon resource names must be globally unique [DBTP-734]

### DIFF
--- a/dbt_copilot_helper/templates/addons/env/aurora-postgres.yml
+++ b/dbt_copilot_helper/templates/addons/env/aurora-postgres.yml
@@ -545,7 +545,7 @@ Resources:
                   - 'logs:PutLogEvents'
                 Resource: 'arn:aws:logs:*:*:*'
 
-  SubscriptionFilter{{ addon_config.prefix }}:
+  {{ addon_config.prefix }}SubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     DependsOn:
       - {{ addon_config.prefix }}DBWriterInstance

--- a/dbt_copilot_helper/templates/addons/env/opensearch.yml
+++ b/dbt_copilot_helper/templates/addons/env/opensearch.yml
@@ -223,7 +223,7 @@ Resources:
         - Key: 'Copilot-Environment'
           Value: !Sub ${Env}
 
-  SubscriptionFilterapplication:
+  {{ addon_config.prefix }}SubscriptionFilterApplication:
     Type: AWS::Logs::SubscriptionFilter
     DependsOn:
       - {{ addon_config.prefix }}OpenSearchApplicationLogGroup
@@ -234,7 +234,7 @@ Resources:
       FilterPattern: ''
       DestinationArn: !If [{{ addon_config.prefix }}CreateProdSubFilter, '{{ log_destination.prod }}', '{{ log_destination.dev }}']
 
-  SubscriptionFilteraudit:
+  {{ addon_config.prefix }}SubscriptionFilterAudit:
     Type: AWS::Logs::SubscriptionFilter
     DependsOn:
       - {{ addon_config.prefix }}OpenSearchAuditLogGroup

--- a/dbt_copilot_helper/templates/addons/env/rds-postgres.yml
+++ b/dbt_copilot_helper/templates/addons/env/rds-postgres.yml
@@ -542,7 +542,7 @@ Resources:
                   - 'logs:PutLogEvents'
                 Resource: 'arn:aws:logs:*:*:*'
 
-  SubscriptionFilter{{ addon_config.prefix }}:
+  {{ addon_config.prefix }}SubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     DependsOn:
       - {{ addon_config.prefix }}DBInstance

--- a/dbt_copilot_helper/templates/addons/env/redis-cluster.yml
+++ b/dbt_copilot_helper/templates/addons/env/redis-cluster.yml
@@ -157,7 +157,7 @@ Resources:
         - url: !GetAtt '{{ addon_config.prefix }}ReplicationGroup.PrimaryEndPoint.Address'
           port: !GetAtt '{{ addon_config.prefix }}ReplicationGroup.PrimaryEndPoint.Port'
 
-  SubscriptionFilterengine:
+  {{ addon_config.prefix }}SubscriptionFilterEngine:
     Type: AWS::Logs::SubscriptionFilter
     DependsOn:
       - {{ addon_config.prefix }}RedisEngineLogGroup
@@ -168,7 +168,7 @@ Resources:
       FilterPattern: ''
       DestinationArn: !If [{{ addon_config.prefix }}CreateProdSubFilter, '{{ log_destination.prod }}', '{{ log_destination.dev }}']
 
-  SubscriptionFilterslow:
+  {{ addon_config.prefix }}SubscriptionFilterSlow:
     Type: AWS::Logs::SubscriptionFilter
     DependsOn:
       - {{ addon_config.prefix }}RedisSlowLogGroup

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "1.1.1"
+version = "1.1.2"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-aurora-db.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-aurora-db.yml
@@ -543,7 +543,7 @@ Resources:
                   - 'logs:PutLogEvents'
                 Resource: 'arn:aws:logs:*:*:*'
 
-  SubscriptionFiltermyAuroraDb:
+  myAuroraDbSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     DependsOn:
       - myAuroraDbDBWriterInstance

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-opensearch-longer.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-opensearch-longer.yml
@@ -221,7 +221,7 @@ Resources:
         - Key: 'Copilot-Environment'
           Value: !Sub ${Env}
 
-  SubscriptionFilterapplication:
+  myOpensearchLongerSubscriptionFilterApplication:
     Type: AWS::Logs::SubscriptionFilter
     DependsOn:
       - myOpensearchLongerOpenSearchApplicationLogGroup
@@ -232,7 +232,7 @@ Resources:
       FilterPattern: ''
       DestinationArn: !If [myOpensearchLongerCreateProdSubFilter, '', '']
 
-  SubscriptionFilteraudit:
+  myOpensearchLongerSubscriptionFilterAudit:
     Type: AWS::Logs::SubscriptionFilter
     DependsOn:
       - myOpensearchLongerOpenSearchAuditLogGroup

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-opensearch.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-opensearch.yml
@@ -221,7 +221,7 @@ Resources:
         - Key: 'Copilot-Environment'
           Value: !Sub ${Env}
 
-  SubscriptionFilterapplication:
+  myOpensearchSubscriptionFilterApplication:
     Type: AWS::Logs::SubscriptionFilter
     DependsOn:
       - myOpensearchOpenSearchApplicationLogGroup
@@ -232,7 +232,7 @@ Resources:
       FilterPattern: ''
       DestinationArn: !If [myOpensearchCreateProdSubFilter, '', '']
 
-  SubscriptionFilteraudit:
+  myOpensearchSubscriptionFilterAudit:
     Type: AWS::Logs::SubscriptionFilter
     DependsOn:
       - myOpensearchOpenSearchAuditLogGroup

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-rds-db.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-rds-db.yml
@@ -540,7 +540,7 @@ Resources:
                   - 'logs:PutLogEvents'
                 Resource: 'arn:aws:logs:*:*:*'
 
-  SubscriptionFiltermyRdsDb:
+  myRdsDbSubscriptionFilter:
     Type: AWS::Logs::SubscriptionFilter
     DependsOn:
       - myRdsDbDBInstance

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-redis.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-redis.yml
@@ -155,7 +155,7 @@ Resources:
         - url: !GetAtt 'myRedisReplicationGroup.PrimaryEndPoint.Address'
           port: !GetAtt 'myRedisReplicationGroup.PrimaryEndPoint.Port'
 
-  SubscriptionFilterengine:
+  myRedisSubscriptionFilterEngine:
     Type: AWS::Logs::SubscriptionFilter
     DependsOn:
       - myRedisRedisEngineLogGroup
@@ -166,7 +166,7 @@ Resources:
       FilterPattern: ''
       DestinationArn: !If [myRedisCreateProdSubFilter, '', '']
 
-  SubscriptionFilterslow:
+  myRedisSubscriptionFilterSlow:
     Type: AWS::Logs::SubscriptionFilter
     DependsOn:
       - myRedisRedisSlowLogGroup


### PR DESCRIPTION
- Fix so bumping patch version number
- All resources must be prefixed with `{{ addon_config.prefix }}` otherwise they will conflict
- Haven't added an overall test to check this due to time constraint, though maybe one could be implemented in future.
