### PR TITLE
fix: enable monitoring addon by default

### DIFF
--- a/dbt_copilot_helper/default-addons.yml
+++ b/dbt_copilot_helper/default-addons.yml
@@ -11,3 +11,9 @@ subscription-filter:
 
 vpc:
   type: vpc
+
+monitoring:
+  type: monitoring
+  environments:
+    default:
+      enable_ops_center: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "1.1.2"
+version = "1.1.3"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/test_command_copilot.py
+++ b/tests/copilot_helper/test_command_copilot.py
@@ -100,6 +100,7 @@ class TestMakeAddonCommand:
                     "my-s3-bucket.yml",
                     "my-s3-bucket-with-an-object.yml",
                     "addons.parameters.yml",
+                    "monitoring.yml",
                     "vpc.yml",
                 ],
                 [
@@ -117,6 +118,7 @@ class TestMakeAddonCommand:
                     "my-opensearch.yml",
                     "my-opensearch-longer.yml",
                     "addons.parameters.yml",
+                    "monitoring.yml",
                     "vpc.yml",
                 ],
                 ["appconfig-ipfilter.yml", "subscription-filter.yml"],
@@ -124,19 +126,19 @@ class TestMakeAddonCommand:
             ),
             (
                 "rds_addons.yml",
-                ["my-rds-db.yml", "addons.parameters.yml", "vpc.yml"],
+                ["my-rds-db.yml", "addons.parameters.yml", "monitoring.yml", "vpc.yml"],
                 ["appconfig-ipfilter.yml", "subscription-filter.yml"],
                 True,
             ),
             (
                 "redis_addons.yml",
-                ["my-redis.yml", "addons.parameters.yml", "vpc.yml"],
+                ["my-redis.yml", "addons.parameters.yml", "monitoring.yml", "vpc.yml"],
                 ["appconfig-ipfilter.yml", "subscription-filter.yml"],
                 False,
             ),
             (
                 "aurora_addons.yml",
-                ["my-aurora-db.yml", "addons.parameters.yml", "vpc.yml"],
+                ["my-aurora-db.yml", "addons.parameters.yml", "monitoring.yml", "vpc.yml"],
                 ["appconfig-ipfilter.yml", "subscription-filter.yml"],
                 True,
             ),


### PR DESCRIPTION
This change makes the monitoring addon part of the default addons, it's backwards compatible with deploy repos that currently have a monitoring addon configured.