### PR TITLE
fix: lambda related resource names must be unique [DBTP-736]

### DIFF
--- a/dbt_copilot_helper/templates/addons/env/aurora-postgres.yml
+++ b/dbt_copilot_helper/templates/addons/env/aurora-postgres.yml
@@ -294,7 +294,7 @@ Resources:
   {{ addon_config.prefix }}LambdaFunction:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub "${App}-${Env}-aurora-create-user"
+      FunctionName: !Sub "${App}-${Env}-{{ addon_config.prefix }}-aurora-create-user"
       Handler: index.handler
       Runtime: python3.11
       Layers:
@@ -501,7 +501,7 @@ Resources:
   {{ addon_config.prefix }}LambdaFunctionExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${App}-${Env}-aurora-user"
+      RoleName: !Sub "${App}-${Env}-{{ addon_config.prefix }}-aurora-user"
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:

--- a/dbt_copilot_helper/templates/addons/env/rds-postgres.yml
+++ b/dbt_copilot_helper/templates/addons/env/rds-postgres.yml
@@ -292,7 +292,7 @@ Resources:
   {{ addon_config.prefix }}LambdaFunction:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub "${App}-${Env}-rds-create-user"
+      FunctionName: !Sub "${App}-${Env}-{{ addon_config.prefix }}-rds-create-user"
       Handler: index.handler
       Runtime: python3.11
       Layers:
@@ -498,7 +498,7 @@ Resources:
   {{ addon_config.prefix }}LambdaFunctionExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${App}-${Env}-rds-user"
+      RoleName: !Sub "${App}-${Env}-{{ addon_config.prefix }}-rds-user"
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "1.1.3"
+version = "1.1.4"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-aurora-db.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-aurora-db.yml
@@ -292,7 +292,7 @@ Resources:
   myAuroraDbLambdaFunction:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub "${App}-${Env}-aurora-create-user"
+      FunctionName: !Sub "${App}-${Env}-myAuroraDb-aurora-create-user"
       Handler: index.handler
       Runtime: python3.11
       Layers:
@@ -499,7 +499,7 @@ Resources:
   myAuroraDbLambdaFunctionExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${App}-${Env}-aurora-user"
+      RoleName: !Sub "${App}-${Env}-myAuroraDb-aurora-user"
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-rds-db.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-rds-db.yml
@@ -290,7 +290,7 @@ Resources:
   myRdsDbLambdaFunction:
     Type: AWS::Lambda::Function
     Properties:
-      FunctionName: !Sub "${App}-${Env}-rds-create-user"
+      FunctionName: !Sub "${App}-${Env}-myRdsDb-rds-create-user"
       Handler: index.handler
       Runtime: python3.11
       Layers:
@@ -496,7 +496,7 @@ Resources:
   myRdsDbLambdaFunctionExecutionRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: !Sub "${App}-${Env}-rds-user"
+      RoleName: !Sub "${App}-${Env}-myRdsDb-rds-user"
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:


### PR DESCRIPTION
- bump patch version as this is a fix
- make resource names for lambda and lambda role unique to each addon name