### PR TITLE
fix: allow for hyphenated service names [DBTP-741]

### DIFF
--- a/dbt_copilot_helper/commands/dns.py
+++ b/dbt_copilot_helper/commands/dns.py
@@ -716,7 +716,7 @@ def find_domain_rules(action, delete, project_profile, env, app, svc):
     elb_client = project_session.client("elbv2")
     acm_client = project_session.client("acm")
 
-    loadbalancerarn = get_load_balancer_configuration(project_session, app, svc, env)[
+    loadbalancerarn = get_load_balancer_configuration(project_session, app, env, svc)[
         "LoadBalancers"
     ][0]["LoadBalancerArn"]
 
@@ -884,7 +884,7 @@ def cdn_list(project_profile, env, app, svc):
 
     elb_client = project_session.client("elbv2")
 
-    loadbalancerarn = get_load_balancer_configuration(project_session, app, svc, env)[
+    loadbalancerarn = get_load_balancer_configuration(project_session, app, env, svc)[
         "LoadBalancers"
     ][0]["LoadBalancerArn"]
 

--- a/dbt_copilot_helper/commands/dns.py
+++ b/dbt_copilot_helper/commands/dns.py
@@ -555,7 +555,7 @@ def assign(app, domain_profile, project_profile, svc, env):
     ensure_cwd_is_repo_root()
     # Find the Load Balancer name.
     domain_name, load_balancer_configuration = get_load_balancer_domain_and_configuration(
-        project_session, app, svc, env
+        project_session, app, env, svc
     )
     elb_name = load_balancer_configuration["DNSName"]
 

--- a/dbt_copilot_helper/commands/waf.py
+++ b/dbt_copilot_helper/commands/waf.py
@@ -62,7 +62,7 @@ def attach_waf(app, project_profile, svc, env):
         exit()
 
     domain_name, load_balancer_configuration = get_load_balancer_domain_and_configuration(
-        project_session, app, svc, env
+        project_session, app, env, svc
     )
 
     elb_arn = load_balancer_configuration["LoadBalancerArn"]
@@ -158,7 +158,7 @@ def custom_waf(app, project_profile, svc, env, waf_path):
     )
 
     domain_name, load_balancer_configuration = get_load_balancer_domain_and_configuration(
-        project_session, app, svc, env
+        project_session, app, env, svc
     )
     elb_arn = load_balancer_configuration["LoadBalancerArn"]
     elb_name = load_balancer_configuration["DNSName"]

--- a/dbt_copilot_helper/utils/aws.py
+++ b/dbt_copilot_helper/utils/aws.py
@@ -281,9 +281,14 @@ def get_load_balancer_configuration(
 
     if no_items:
         click.echo(
-            click.style("There are no services matching ", fg="red")
-            + click.style(f"{svc}", fg="white", bold=True)
-            + click.style(" in this aws account", fg="red"),
+            click.style("There are no services called ", fg="red")
+            + click.style(f"{svc} ", fg="white", bold=True)
+            + click.style("for environment ", fg="red")
+            + click.style(f"{env} ", fg="white", bold=True)
+            + click.style("of application ", fg="red")
+            + click.style(f"{app} ", fg="white", bold=True)
+            + click.style("in AWS account ", fg="red")
+            + click.style(f"{project_session.profile_name}", fg="white", bold=True),
         )
         exit()
 

--- a/dbt_copilot_helper/utils/aws.py
+++ b/dbt_copilot_helper/utils/aws.py
@@ -213,7 +213,7 @@ def get_codestar_connection_arn(app_name):
 
 
 def get_load_balancer_domain_and_configuration(
-    project_session: Session, app: str, svc: str, env: str
+    project_session: Session, app: str, env: str, svc: str
 ) -> Tuple[str, dict]:
     response = get_load_balancer_configuration(project_session, app, env, svc)
 
@@ -261,9 +261,12 @@ def get_load_balancer_configuration(
 
     if no_items:
         click.echo(
-            click.style("There are no clusters matching ", fg="red")
+            click.style("There are no clusters for environment ", fg="red")
+            + click.style(f"{env} ", fg="white", bold=True)
+            + click.style("of application ", fg="red")
             + click.style(f"{app} ", fg="white", bold=True)
-            + click.style("in this AWS account", fg="red"),
+            + click.style("in AWS account ", fg="red")
+            + click.style(f"{project_session.profile_name}", fg="white", bold=True),
         )
         exit()
 

--- a/dbt_copilot_helper/utils/aws.py
+++ b/dbt_copilot_helper/utils/aws.py
@@ -215,7 +215,7 @@ def get_codestar_connection_arn(app_name):
 def get_load_balancer_domain_and_configuration(
     project_session: Session, app: str, svc: str, env: str
 ) -> Tuple[str, dict]:
-    response = get_load_balancer_configuration(project_session, app, svc, env)
+    response = get_load_balancer_configuration(project_session, app, env, svc)
 
     # Find the domain name
     with open(f"./copilot/{svc}/manifest.yml", "r") as fd:
@@ -246,7 +246,7 @@ def get_load_balancer_domain_and_configuration(
 
 
 def get_load_balancer_configuration(
-    project_session: Session, app: str, svc: str, env: str
+    project_session: Session, app: str, env: str, svc: str
 ) -> list[Session]:
     def separate_hyphenated_application_environment_and_service(
         hyphenated_string, number_of_items_of_interest, number_of_trailing_items

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "1.1.4"
+version = "1.1.5"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/conftest.py
+++ b/tests/copilot_helper/conftest.py
@@ -305,6 +305,7 @@ def mock_codestar_connections_boto_client(get_aws_session_or_abort, connection_n
 
 def mock_aws_client(get_aws_session_or_abort, client=None):
     session = MagicMock(name="session-mock")
+    session.profile_name = "foo"
     if not client:
         client = MagicMock(name="client-mock")
     session.client.return_value = client

--- a/tests/copilot_helper/test_command_dns.py
+++ b/tests/copilot_helper/test_command_dns.py
@@ -555,7 +555,9 @@ def test_assign(ensure_cwd_is_repo_root, get_aws_session_or_abort):
             "dev",
         ],
     )
-    assert result.output.startswith("There are no clusters matching")
+    assert (
+        "There are no clusters for environment dev of application some-app " "in AWS account foo"
+    ) in result.output
 
 
 @pytest.mark.parametrize(

--- a/tests/copilot_helper/test_command_waf.py
+++ b/tests/copilot_helper/test_command_waf.py
@@ -113,10 +113,10 @@ def test_attach_waf(alias_session):
         DefaultActions=[{"Type": "forward", "TargetGroupArn": target_group_arn}],
     )
     ecs_client = session.client("ecs")
-    ecs_client.create_cluster(clusterName="app-env-svc")
+    ecs_client.create_cluster(clusterName="app-env-Cluster-c0PIlotiD3ntIF3r")
     ecs_client.create_service(
-        cluster="app-env-svc",
-        serviceName="app-env-svc",
+        cluster="app-env-Cluster-c0PIlotiD3ntIF3r",
+        serviceName="app-env-svc-Service-c0PIlotiD3ntIF3r",
         loadBalancers=[{"loadBalancerName": "foo", "targetGroupArn": target_group_arn}],
     )
     open_mock = mock_open(read_data='{"environments": {"env": {"http": {"alias": "blah"}}}}')

--- a/tests/copilot_helper/utils/test_aws.py
+++ b/tests/copilot_helper/utils/test_aws.py
@@ -369,11 +369,20 @@ def test_get_load_balancer_domain_and_configuration_no_services(capfd):
 @mock_elbv2
 @mock_ec2
 @mock_ecs
-def test_get_load_balancer_domain_and_configuration(tmp_path):
+@pytest.mark.parametrize(
+    "svc_name",
+    [
+        ALPHANUMERIC_SERVICE_NAME,
+        "test",
+        "test-service",
+        "test-service-name",
+    ],
+)
+def test_get_load_balancer_domain_and_configuration(tmp_path, svc_name):
     cluster_name = (
         f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-{CLUSTER_NAME_SUFFIX}"
     )
-    service_name = f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-{ALPHANUMERIC_SERVICE_NAME}-{SERVICE_NAME_SUFFIX}"
+    service_name = f"{HYPHENATED_APPLICATION_NAME}-{ALPHANUMERIC_ENVIRONMENT_NAME}-{svc_name}-{SERVICE_NAME_SUFFIX}"
     session = boto3.Session()
     mocked_vpc_id = session.client("ec2").create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
     mocked_subnet_id = session.client("ec2").create_subnet(
@@ -407,11 +416,11 @@ def test_get_load_balancer_domain_and_configuration(tmp_path):
         domain_name, load_balancer_configuration = get_load_balancer_domain_and_configuration(
             boto3.Session(),
             HYPHENATED_APPLICATION_NAME,
-            ALPHANUMERIC_SERVICE_NAME,
+            svc_name,
             ALPHANUMERIC_ENVIRONMENT_NAME,
         )
 
-    open_mock.assert_called_once_with(f"./copilot/{ALPHANUMERIC_SERVICE_NAME}/manifest.yml", "r")
+    open_mock.assert_called_once_with(f"./copilot/{svc_name}/manifest.yml", "r")
     assert domain_name == "somedomain.tld"
     assert load_balancer_configuration["LoadBalancerArn"] == mocked_load_balancer_arn
     assert load_balancer_configuration["LoadBalancerName"] == "foo"

--- a/tests/copilot_helper/utils/test_aws.py
+++ b/tests/copilot_helper/utils/test_aws.py
@@ -342,7 +342,8 @@ def test_get_load_balancer_domain_and_configuration_no_clusters(capfd):
     out, _ = capfd.readouterr()
 
     assert (
-        out == f"There are no clusters matching {HYPHENATED_APPLICATION_NAME} in this AWS account\n"
+        out == f"There are no clusters for environment {ALPHANUMERIC_ENVIRONMENT_NAME} of "
+        f"application {HYPHENATED_APPLICATION_NAME} in AWS account default\n"
     )
 
 
@@ -355,8 +356,8 @@ def test_get_load_balancer_domain_and_configuration_no_services(capfd):
         get_load_balancer_domain_and_configuration(
             boto3.Session(),
             HYPHENATED_APPLICATION_NAME,
-            ALPHANUMERIC_SERVICE_NAME,
             ALPHANUMERIC_ENVIRONMENT_NAME,
+            ALPHANUMERIC_SERVICE_NAME,
         )
 
     out, _ = capfd.readouterr()
@@ -414,10 +415,7 @@ def test_get_load_balancer_domain_and_configuration(tmp_path, svc_name):
 
     with patch("dbt_copilot_helper.utils.aws.open", open_mock):
         domain_name, load_balancer_configuration = get_load_balancer_domain_and_configuration(
-            boto3.Session(),
-            HYPHENATED_APPLICATION_NAME,
-            svc_name,
-            ALPHANUMERIC_ENVIRONMENT_NAME,
+            boto3.Session(), HYPHENATED_APPLICATION_NAME, ALPHANUMERIC_ENVIRONMENT_NAME, svc_name
         )
 
     open_mock.assert_called_once_with(f"./copilot/{svc_name}/manifest.yml", "r")
@@ -449,7 +447,7 @@ def test_get_load_balancer_domain_and_configuration_no_domain(
         contents=content,
     )
     with pytest.raises(SystemExit):
-        get_load_balancer_domain_and_configuration("test", "testapp", svc_name, "test")
+        get_load_balancer_domain_and_configuration("test", "testapp", "test", svc_name)
     assert (
         capsys.readouterr().out
         == f"{exp_error}, please check the ./copilot/{svc_name}/manifest.yml file\n"

--- a/tests/copilot_helper/utils/test_aws.py
+++ b/tests/copilot_helper/utils/test_aws.py
@@ -363,7 +363,9 @@ def test_get_load_balancer_domain_and_configuration_no_services(capfd):
     out, _ = capfd.readouterr()
 
     assert (
-        out == f"There are no services matching {ALPHANUMERIC_SERVICE_NAME} in this aws account\n"
+        out == f"There are no services called {ALPHANUMERIC_SERVICE_NAME} for environment "
+        f"{ALPHANUMERIC_ENVIRONMENT_NAME} of application {HYPHENATED_APPLICATION_NAME} "
+        f"in AWS account default\n"
     )
 
 


### PR DESCRIPTION
- Allow for services with hyphenated names `icms-web` for example.
- UX improvements around output when cluster or service not found.
- Refactored to correct order of arguments to: app, env, svc.