### PR TITLE
DBTP-438 Allow service containers to use temporary file system

### DIFF
--- a/dbt_copilot_helper/templates/svc/overrides/cfn.patches.yml
+++ b/dbt_copilot_helper/templates/svc/overrides/cfn.patches.yml
@@ -1,3 +1,14 @@
 - op: replace
   path: /Resources/LogGroup/Properties/LogGroupName
   value: !Sub '/copilot/${AppName}/${EnvName}/${WorkloadName}'
+
+- op: add
+  path: /Resources/TaskDefinition/Properties/ContainerDefinitions/0/MountPoints
+  value:
+    - ContainerPath: /tmp
+      SourceVolume: temporary-fs
+
+- op: add
+  path: /Resources/TaskDefinition/Properties/Volumes
+  value:
+    - Name: temporary-fs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "1.2.0"
+version = "1.2.1"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/fixtures/make_addons/expected/web/overrides/cfn.patches.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/web/overrides/cfn.patches.yml
@@ -1,3 +1,14 @@
 - op: replace
   path: /Resources/LogGroup/Properties/LogGroupName
   value: !Sub '/copilot/${AppName}/${EnvName}/${WorkloadName}'
+
+- op: add
+  path: /Resources/TaskDefinition/Properties/ContainerDefinitions/0/MountPoints
+  value:
+    - ContainerPath: /tmp
+      SourceVolume: temporary-fs
+
+- op: add
+  path: /Resources/TaskDefinition/Properties/Volumes
+  value:
+    - Name: temporary-fs


### PR DESCRIPTION
Addresses https://uktrade.atlassian.net/browse/DBTP-438

Adds the required override blocks to stop us having to manually replace them every time we run `make-addons`.