### PR TITLE
DBTP-681 Add AWS Copilot CLI to debian/python image

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,18 +59,6 @@ Run `pip install <file>` and confirm the installation has worked by running `cop
 > [!IMPORTANT]
 > When testing is complete, do not forget to revert the `dbt-copilot-tools` installation back to what it was; e.g. `pip install dbt-copilot-tools==0.1.39`.
 
-#### [`Dockerfile.debian`](Dockerfile.debian)
-
-This `Dockerfile` is used to create a Docker image that supports multiple versions of Python runtimes via [`pyenv`](https://github.com/pyenv/pyenv). The `tox` configuration file determines the Python versions to be tested against.
-
-#### Adding a Python version
-
-Add the Python version(s) to `Dockerfile.debian` and `tox.ini`.
-
-Run `docker build -f Dockerfile.debian -t debian/python .` to build the image.
-
-For Platform developers, the `push` commands can be found in [AWS ECR](https://eu-west-2.console.aws.amazon.com/ecr/repositories).
-
 ### Publishing
 
 To publish the Python package `dbt-copilot-tools`, you will need an API token.

--- a/images/debian-python/Dockerfile.debian
+++ b/images/debian-python/Dockerfile.debian
@@ -32,8 +32,10 @@ RUN apt-get update \
   && apt-get clean autoclean \
   && apt-get autoremove -y \
   && rm -rf /var/lib/apt/lists/* \
-  && rm -f /var/cache/apt/archives/*.deb \
-  && git clone https://github.com/pyenv/pyenv .pyenv \
+  && rm -f /var/cache/apt/archives/*.deb
+
+# Install Pyenv and required Python versions
+RUN git clone https://github.com/pyenv/pyenv .pyenv \
   && pyenv install ${PYTHON_VERSIONS} \
   && pyenv global $(echo ${PYTHON_VERSIONS} | awk '{ print $NF }')
 
@@ -41,3 +43,9 @@ RUN apt-get update \
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip" \
   && unzip awscliv2.zip \
   && ./aws/install
+
+# Install AWS Copilot
+RUN curl -Lo copilot https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux-arm64 \
+  && chmod +x copilot \
+  && mv copilot /usr/local/bin/copilot \
+  && copilot --version

--- a/images/debian-python/README.md
+++ b/images/debian-python/README.md
@@ -1,0 +1,13 @@
+#### [`Dockerfile.debian`](Dockerfile.debian)
+
+This `Dockerfile` is used to create a Docker image that supports multiple versions of Python runtimes via [`pyenv`](https://github.com/pyenv/pyenv). The `tox` configuration file determines the Python versions to be tested against.
+
+It also has the [AWS Copilot CLI](https://aws.github.io/copilot-cli/) installed to support our pull request and regression test pipelines.
+
+#### Adding a Python version
+
+Add the Python version(s) to `Dockerfile.debian` and `tox.ini`.
+
+Run `docker build -f Dockerfile.debian -t debian/python .` to build the image.
+
+For Platform developers, the `push` commands can be found in [AWS ECR](https://eu-west-2.console.aws.amazon.com/ecr/repositories).


### PR DESCRIPTION
To support our pull request and regression test pipelines.

Has already been published and tested.