### PR TITLE
DBTP-770 Run unit tests in parallel by Python version in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,6 @@ jobs:
           poetry install
 
       - name: Test against Python ${PYTHON_VERSION}
-        run: poetry run tox -e "py${PYTHON_VERSION/./}"
+        run: poetry run pytest
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+name: test
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version:
+          - "3.12"
+          - "3.11"
+          - "3.10"
+          - "3.9"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry install
+
+      - name: Test against Python ${PYTHON_VERSION}
+        run: tox -e "py${PYTHON_VERSION/./}"
+        env:
+          PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,6 @@ jobs:
           poetry install
 
       - name: Test against Python ${PYTHON_VERSION}
-        run: tox -e "py${PYTHON_VERSION/./}"
+        run: poetry run tox -e "py${PYTHON_VERSION/./}"
         env:
           PYTHON_VERSION: ${{ matrix.python-version }}

--- a/buildspec.test.yml
+++ b/buildspec.test.yml
@@ -14,5 +14,4 @@ phases:
 
   build:
     commands:
-      - echo Running tests
-      - poetry run tox
+      - echo Leaving placeholder here for when we merge https://github.com/uktrade/copilot-tools/pull/309


### PR DESCRIPTION
Approximately 6 times faster than running them in serial in CodeBuild, which we can save for running the regression tests.