### PR TITLE
chore: Remove -d / --directory arguments and default param from make_addons

### DIFF
--- a/dbt_copilot_helper/COMMANDS.md
+++ b/dbt_copilot_helper/COMMANDS.md
@@ -439,13 +439,10 @@ copilot-helper copilot (make-addons|get-env-secrets)
 ## Usage
 
 ```
-copilot-helper copilot make-addons [-d <directory>] 
+copilot-helper copilot make-addons 
 ```
 
 ## Options
-
-- `-d
---directory <text>` _Defaults to .._
 
 - `--help <boolean>` _Defaults to False._
   - Show this message and exit.

--- a/dbt_copilot_helper/commands/copilot.py
+++ b/dbt_copilot_helper/commands/copilot.py
@@ -192,10 +192,9 @@ def _generate_svc_overrides(base_path, templates, name):
 
 
 @copilot.command()
-@click.option("-d", "--directory", type=str, default=".")
-def make_addons(directory="."):
+def make_addons():
     """Generate addons CloudFormation for each environment."""
-    output_dir = Path(directory).absolute()
+    output_dir = Path(".").absolute()
 
     ensure_cwd_is_repo_root()
     templates = setup_templates()
@@ -215,7 +214,7 @@ def make_addons(directory="."):
     custom_resources = _get_custom_resources()
 
     svc_names = list_copilot_local_services()
-    base_path = Path(directory)
+    base_path = Path(".")
     for svc_name in svc_names:
         _generate_svc_overrides(base_path, templates, svc_name)
 


### PR DESCRIPTION
Small PR to suggest the removal of what doesn't seem to be a used param / argument for make_addons