### PR TITLE
fix: RDS parameter group family

### DIFF
--- a/dbt_copilot_helper/templates/addons/env/rds-postgres.yml
+++ b/dbt_copilot_helper/templates/addons/env/rds-postgres.yml
@@ -174,7 +174,7 @@ Resources:
     UpdateReplacePolicy: Retain
     Properties:
       Description: !Ref 'AWS::StackName'
-      Family: 'postgres13'
+      Family: 'postgres{{ addon_config.version | int }}'
       Parameters:
         client_encoding: 'UTF8'
         log_statement: ddl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ line-length = 100
 
 [tool.poetry]
 name = "dbt-copilot-tools"
-version = "4.0.0"
+version = "4.0.1"
 description = "Set of tools to help transfer applications/services from GOV.UK PaaS to DBT PaaS augmenting AWS Copilot."
 authors = ["Department for Business and Trade Platform Team <sre-team@digital.trade.gov.uk>"]
 license = "MIT"

--- a/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-rds-db.yml
+++ b/tests/copilot_helper/fixtures/make_addons/expected/environments/addons/my-rds-db.yml
@@ -172,7 +172,7 @@ Resources:
     UpdateReplacePolicy: Retain
     Properties:
       Description: !Ref 'AWS::StackName'
-      Family: 'postgres13'
+      Family: 'postgres14'
       Parameters:
         client_encoding: 'UTF8'
         log_statement: ddl


### PR DESCRIPTION
Currently RDS addons only work if you deploy postgres 13, this PR resolves that issue by using the set version of postgres when generating the postgres parameter group.